### PR TITLE
Istio: Fix Virtualservice.

### DIFF
--- a/apis/networking/v1beta1/api_types.go
+++ b/apis/networking/v1beta1/api_types.go
@@ -90,8 +90,8 @@ type API struct {
 	Status APIStatus `json:"status,omitempty"`
 }
 
-func (api *API) GetName() string {
-	return fmt.Sprintf("%s/%s", api.Namespace, api.Name)
+func (api *API) GetFullName() string {
+	return fmt.Sprintf("%s.%s", api.Namespace, api.Name)
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/ingressproviders/istioprovider/provider.go
+++ b/pkg/ingressproviders/istioprovider/provider.go
@@ -52,11 +52,11 @@ func New(logger logr.Logger, client client.Client) *IstioProvider {
 }
 
 func (is *IstioProvider) Create(ctx context.Context, api v1beta1.API) error {
-	httpRoutes := is.GetHTTPRoutes(api)
+	httpRoutes := is.getHTTPRoutes(api)
 
 	virtualService := istio.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      api.Name + api.Namespace,
+			Name:      api.GetFullName(),
 			Namespace: KuadrantNamespace,
 		},
 		Spec: v1alpha3.VirtualService{
@@ -65,12 +65,11 @@ func (is *IstioProvider) Create(ctx context.Context, api v1beta1.API) error {
 			Http:     httpRoutes,
 		},
 	}
-
 	is.addOwnerReference(virtualService, api)
 
 	err := is.K8sClient.Create(ctx, &virtualService)
 	if err != nil {
-		return fmt.Errorf("failing to create Istio virtualservice for %s: %w", api.GetName(), err)
+		return fmt.Errorf("failing to create Istio virtualservice for %s: %w", api.GetFullName(), err)
 	}
 
 	return nil
@@ -88,11 +87,10 @@ func (is *IstioProvider) addOwnerReference(virtualService istio.VirtualService, 
 		}))
 }
 
-func (is *IstioProvider) GetHTTPRoutes(api v1beta1.API) []*v1alpha3.HTTPRoute {
+func (is *IstioProvider) getHTTPRoutes(api v1beta1.API) []*v1alpha3.HTTPRoute {
 	// Let's create the virtual service and the routes.
 	httpRoutes := make([]*v1alpha3.HTTPRoute, len(api.Spec.Operations))
-
-	for _, operation := range api.Spec.Operations {
+	for i, operation := range api.Spec.Operations {
 		//TODO: Create the proper AuthorizationPolicy based on the security field.
 		httpRoute := v1alpha3.HTTPRoute{
 			Name: operation.ID,
@@ -123,7 +121,7 @@ func (is *IstioProvider) GetHTTPRoutes(api v1beta1.API) []*v1alpha3.HTTPRoute {
 				httpRoute.Route = append(httpRoute.Route, &httpRouteDestination)
 			}
 		}
-		httpRoutes = append(httpRoutes, &httpRoute)
+		httpRoutes[i] = &httpRoute
 	}
 	return httpRoutes
 }


### PR DESCRIPTION
If an array is started with null values, the value should be added to
the specific entry instead of append, if not will push new entries to
the array.

Also, the function should be private, due it's not part of the interface.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>