### PR TITLE
Makefile: specify SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:


### PR DESCRIPTION
Required to run in linux envs. `sh` does not contain `source` builtin command