### PR TITLE
Fix API reconciliation

### DIFF
--- a/controllers/apiproduct_api_handler.go
+++ b/controllers/apiproduct_api_handler.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	networkingv1beta1 "github.com/kuadrant/kuadrant-controller/apis/networking/v1beta1"
+)
+
+// APIProductAPIEventMapper is an EventHandler that maps API object events
+// to APIProduct events.
+type APIProductAPIEventMapper struct {
+	K8sClient client.Client
+	Logger    logr.Logger
+}
+
+func (a *APIProductAPIEventMapper) Map(obj client.Object) []reconcile.Request {
+	a.Logger.V(1).Info("Processing object", "Name", obj.GetName(), "Namespace", obj.GetNamespace())
+
+	apiProductList := &networkingv1beta1.APIProductList{}
+	// all namespaces
+	// filter by API UID
+	err := a.K8sClient.List(context.Background(), apiProductList, client.HasLabels{apiLabelKey(string(obj.GetUID()))})
+	if err != nil {
+		a.Logger.Error(err, "reading apiproduct list")
+		return nil
+	}
+
+	requests := []reconcile.Request{}
+	for idx := range apiProductList.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      apiProductList.Items[idx].GetName(),
+			Namespace: apiProductList.Items[idx].GetNamespace(),
+		}})
+	}
+
+	return requests
+}

--- a/controllers/apiproduct_utils.go
+++ b/controllers/apiproduct_utils.go
@@ -29,6 +29,10 @@ const (
 	KuadrantAPILabelValue  = "true"
 )
 
+func apiLabelKey(uid string) string {
+	return fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid)
+}
+
 func replaceAPILabels(apip *networkingv1beta1.APIProduct, desiredAPIUIDs []string) bool {
 	existingLabels := apip.GetLabels()
 
@@ -49,9 +53,8 @@ func replaceAPILabels(apip *networkingv1beta1.APIProduct, desiredAPIUIDs []strin
 
 	desiredAPILabels := map[string]string{}
 	for _, uid := range desiredAPIUIDs {
-		labelKey := fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid)
-		desiredAPILabels[labelKey] = KuadrantAPILabelValue
-		existingLabels[labelKey] = KuadrantAPILabelValue
+		desiredAPILabels[apiLabelKey(uid)] = KuadrantAPILabelValue
+		existingLabels[apiLabelKey(uid)] = KuadrantAPILabelValue
 	}
 
 	apip.SetLabels(existingLabels)

--- a/controllers/apiproduct_utils.go
+++ b/controllers/apiproduct_utils.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	networkingv1beta1 "github.com/kuadrant/kuadrant-controller/apis/networking/v1beta1"
+)
+
+const (
+	KuadrantAPILabelPrefix = "api.kuadrant.io/"
+	KuadrantAPILabelValue  = "true"
+)
+
+func replaceAPILabels(apip *networkingv1beta1.APIProduct, desiredAPIUIDs []string) bool {
+	existingLabels := apip.GetLabels()
+
+	if existingLabels == nil {
+		existingLabels = map[string]string{}
+	}
+
+	existingAPILabels := map[string]string{}
+
+	// existing API UIDs not included in desiredAPIUIDs are deleted
+	for k := range existingLabels {
+		if strings.HasPrefix(k, KuadrantAPILabelPrefix) {
+			existingAPILabels[k] = KuadrantAPILabelValue
+			// it is safe to remove keys while looping in range
+			delete(existingLabels, k)
+		}
+	}
+
+	desiredAPILabels := map[string]string{}
+	for _, uid := range desiredAPIUIDs {
+		labelKey := fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid)
+		desiredAPILabels[labelKey] = KuadrantAPILabelValue
+		existingLabels[labelKey] = KuadrantAPILabelValue
+	}
+
+	apip.SetLabels(existingLabels)
+
+	return !reflect.DeepEqual(existingAPILabels, desiredAPILabels)
+}

--- a/controllers/apiproduct_utils_test.go
+++ b/controllers/apiproduct_utils_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -43,10 +42,10 @@ func TestReplaceAPILabels(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "apiproduct01",
 			Labels: map[string]string{
-				"app": "database",
-				fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid1): KuadrantAPILabelValue,
-				fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid2): KuadrantAPILabelValue,
-				fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid3): KuadrantAPILabelValue,
+				"app":             "database",
+				apiLabelKey(uid1): KuadrantAPILabelValue,
+				apiLabelKey(uid2): KuadrantAPILabelValue,
+				apiLabelKey(uid3): KuadrantAPILabelValue,
 			},
 		},
 		Spec: networkingv1beta1.APIProductSpec{},
@@ -65,10 +64,10 @@ func TestReplaceAPILabels(t *testing.T) {
 	newLabels := apiProduct.GetLabels()
 
 	expectedLabels := map[string]string{
-		"app": "database",
-		fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid2): KuadrantAPILabelValue,
-		fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid3): KuadrantAPILabelValue,
-		fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid4): KuadrantAPILabelValue,
+		"app":             "database",
+		apiLabelKey(uid2): KuadrantAPILabelValue,
+		apiLabelKey(uid3): KuadrantAPILabelValue,
+		apiLabelKey(uid4): KuadrantAPILabelValue,
 	}
 
 	if !reflect.DeepEqual(newLabels, expectedLabels) {

--- a/controllers/apiproduct_utils_test.go
+++ b/controllers/apiproduct_utils_test.go
@@ -1,0 +1,77 @@
+// +build unit
+
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	networkingv1beta1 "github.com/kuadrant/kuadrant-controller/apis/networking/v1beta1"
+)
+
+var (
+	LOGTEST = ctrl.Log.WithName("test_controllers")
+)
+
+func TestReplaceAPILabels(t *testing.T) {
+	uid1 := "11111"
+	uid2 := "22222"
+	uid3 := "33333"
+	uid4 := "44444"
+	apiProduct := &networkingv1beta1.APIProduct{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "apiproduct01",
+			Labels: map[string]string{
+				"app": "database",
+				fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid1): KuadrantAPILabelValue,
+				fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid2): KuadrantAPILabelValue,
+				fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid3): KuadrantAPILabelValue,
+			},
+		},
+		Spec: networkingv1beta1.APIProductSpec{},
+	}
+
+	// missing api1 from apiproduct labels
+	// api4 additional to existing apiproduct labels
+	desiredAPIUIDs := []string{uid2, uid3, uid4}
+
+	updated := replaceAPILabels(apiProduct, desiredAPIUIDs)
+
+	if !updated {
+		t.Error("update expected")
+	}
+
+	newLabels := apiProduct.GetLabels()
+
+	expectedLabels := map[string]string{
+		"app": "database",
+		fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid2): KuadrantAPILabelValue,
+		fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid3): KuadrantAPILabelValue,
+		fmt.Sprintf("%s%s", KuadrantAPILabelPrefix, uid4): KuadrantAPILabelValue,
+	}
+
+	if !reflect.DeepEqual(newLabels, expectedLabels) {
+		t.Errorf("Resulting expected labels differ: %s", cmp.Diff(newLabels, expectedLabels))
+	}
+}

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -140,6 +140,8 @@ func CreateOrUpdateK8SObject(obj runtime.Object, k8sClient client.Client) error 
 	return k8sClient.Update(context.Background(), k8sObjCopy)
 }
 
+// TODO(eastizle): Generalize this method to be useful for any context.
+// number of deployments or deployment list should be passed as argument.
 func CheckForDeploymentsReady(ns string, k8sClient client.Client) error {
 	deploymentList := &appsv1.DeploymentList{}
 	listOptions := &client.ListOptions{}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/getkin/kin-openapi v0.63.0
 	github.com/go-logr/logr v0.3.0
+	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/kuadrant/authorino v0.0.0-20210422165318-a53c0df15d51
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2


### PR DESCRIPTION
Currently, when service changed OAS or any other annotation, the underlying API object was reconciled, but APIProduct controller was not notified. Hence, Istio deployment was not updated and the changes did not have any effect in the traffic control plane.

The implemented idea is:

APIProduct controller will keep updated labels with UID's of referenced APIs:
```
apiVersion: networking.kuadrant.io/v1beta1
kind: APIProduct
metadata:
  labels:
    api.kuadrant.io/48aab3ea-011f-4298-b0d5-c066617b37b8: "true"
    api.kuadrant.io/c1ae637a-af89-4b42-bf62-2531621ffc52: "true"
    other-arbitrary-label: arbitrary-value
```

APIProduct controller will be watching API objects for events. When an API object changes (with UID 1 for example), the APIProduct controller will query for the list of APIPRoduct resources with the UID 1. Then it will generate reconcile requests for each one of the APIProducts that are referencing the API object changed (with UID 1). When the APIProduct reconciliation loop starts, the controller will update the istio control plane accordingly.

The following code has been removed:
```
	if apip.Status.Ready && apip.Status.ObservedGen == apip.GetGeneration() {
		log.Info("nothing to be done")
		return ctrl.Result{}, nil
	}
```

The reason is because the state that is wanted to be in "desired state" does not rely entirely on the APIProduct spec. It also relies on API objects and other resources like config maps. Thus, the reconcilliation loop cannot be terminated just because the spec of the APIProduct did not change. 

It has been discarded the option of having a list of APIproduct references in the API object. For a simple reason, if a user removes an API reference from the APIProduct spec (not from the cluster), there is no way to update the APIProduct references in the removed API resource.

This PR relies on #34. It should not be merged before.