### PR TITLE
service controller watches owned APIs

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -335,12 +336,12 @@ func (r *ServiceReconciler) getOwnedAPI(ctx context.Context, service *corev1.Ser
 // SetupWithManager sets up the controller with the Manager.
 func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		WithEventFilter(onlyLabeledServices()).
-		For(&corev1.Service{}).
+		For(&corev1.Service{}, builder.WithPredicates(kuadrantServicesPredicate())).
+		Owns(&networkingv1beta1.API{}).
 		Complete(r)
 }
 
-func onlyLabeledServices() predicate.Predicate {
+func kuadrantServicesPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			// Lets filter for only Services that have the kuadrant label and are enabled.


### PR DESCRIPTION
Added watcher for owned `networkingv1beta1.API`

The `OnlyLabeledServices` predicate was registered with `WithEventFilter` builder method. That that predicate is added globally to all watched objects. It was shadowing events from API objects. It has been renamed to `kuadrantServicesPredicate` and applied only to services objects.

Fixes #60 

With this fix, when some API object is deleted AND this API was owned by a service (being labeled for kuadrant), the service controller will get the deletion event and reconcile, effectively, re-creating the API object associated to the service. 

When the service label `discovery.kuadrant.io/enabled` is set to false or deleted, the controller will delete any API owned by that service. 

 