### PR TITLE
Add a named port

### DIFF
--- a/examples/toystore/toystore.yaml
+++ b/examples/toystore/toystore.yaml
@@ -33,6 +33,7 @@ spec:
   selector:
     app: toystore
   ports:
-    - port: 80
+    - name: http
+      port: 80
       protocol: TCP
       targetPort: 3000


### PR DESCRIPTION
istio needs ports to indicate which type of protocol they use. Adding this named port allows for the WASMPlugin to work with the sidecar