### PR TITLE
Harden RateLimitPolicy implementation

### DIFF
--- a/apis/apim/v1alpha1/ratelimitpolicy_types.go
+++ b/apis/apim/v1alpha1/ratelimitpolicy_types.go
@@ -77,6 +77,9 @@ type NetworkingRef struct {
 
 // RateLimitPolicySpec defines the desired state of RateLimitPolicy
 type RateLimitPolicySpec struct {
+	//+listType=map
+	//+listMapKey=type
+	//+listMapKey=name
 	NetworkingRef []NetworkingRef `json:"networkingRef,omitempty"`
 	// route specific staging and actions
 	//+listType=map

--- a/config/crd/bases/apim.kuadrant.io_ratelimitpolicies.yaml
+++ b/config/crd/bases/apim.kuadrant.io_ratelimitpolicies.yaml
@@ -95,6 +95,10 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - name
+                x-kubernetes-list-type: map
               routes:
                 description: route specific staging and actions
                 items:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -171,6 +171,10 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - name
+                x-kubernetes-list-type: map
               routes:
                 description: route specific staging and actions
                 items:
@@ -320,6 +324,60 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - ratelimits
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - envoyfilters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.istio.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,3 +58,57 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - ratelimits
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - envoyfilters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.istio.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/apim/ratelimitpolicy_controller.go
+++ b/controllers/apim/ratelimitpolicy_controller.go
@@ -85,21 +85,21 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 		return ctrl.Result{}, err
 	}
 
-	if rlp.GetDeletionTimestamp() != nil && controllerutil.ContainsFinalizer(&rlp, filtersFinalizer) {
+	if rlp.GetDeletionTimestamp() != nil && controllerutil.ContainsFinalizer(&rlp, patchesFinalizer) {
 		logger.Info("Removing finalizers")
 		if err := r.finalizeEnvoyFilters(ctx, &rlp); err != nil {
 			logger.Error(err, "failed to remove ownerRlp entry from filters patch")
 			return ctrl.Result{}, err
 		}
-		controllerutil.RemoveFinalizer(&rlp, filtersFinalizer)
+		controllerutil.RemoveFinalizer(&rlp, patchesFinalizer)
 		if err := r.BaseReconciler.UpdateResource(ctx, &rlp); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
 
-	if !controllerutil.ContainsFinalizer(&rlp, filtersFinalizer) {
-		controllerutil.AddFinalizer(&rlp, filtersFinalizer)
+	if !controllerutil.ContainsFinalizer(&rlp, patchesFinalizer) {
+		controllerutil.AddFinalizer(&rlp, patchesFinalizer)
 		if err := r.BaseReconciler.UpdateResource(ctx, &rlp); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{Requeue: true}, err
 		}

--- a/controllers/apim/ratelimitpolicy_controller.go
+++ b/controllers/apim/ratelimitpolicy_controller.go
@@ -167,9 +167,9 @@ func (r *RateLimitPolicyReconciler) reconcileWithVirtualService(ctx context.Cont
 
 		// create/update ratelimit filters patch
 		// fetch already existing filters patch or create a new one
-		filtersPatckKey := client.ObjectKey{Namespace: gwKey.Namespace, Name: rlFiltersPatchName(gwKey.Name)}
+		filtersPatchKey := client.ObjectKey{Namespace: gwKey.Namespace, Name: rlFiltersPatchName(gwKey.Name)}
 		filtersPatch := &istio.EnvoyFilter{}
-		if err := r.Client().Get(ctx, filtersPatckKey, filtersPatch); err != nil {
+		if err := r.Client().Get(ctx, filtersPatchKey, filtersPatch); err != nil {
 			if !apierrors.IsNotFound(err) {
 				logger.Error(err, "failed to get ratelimit filters patch")
 				return err

--- a/controllers/apim/ratelimitpolicy_finalizers.go
+++ b/controllers/apim/ratelimitpolicy_finalizers.go
@@ -1,0 +1,134 @@
+package apim
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
+	"github.com/kuadrant/kuadrant-controller/pkg/common"
+	istio "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	filtersFinalizer = "kuadrant.io/ratelimitfilters"
+
+	ownerRlpSeparator = ","
+
+	envoyFilterAnnotationOwnerRLPs = "kuadrant.io/ownerRateLimitPolicies"
+)
+
+// ownerRateLimitPolicies stores the name of any RateLimitPolicy that is dependant
+// upon the contents of an EnvoyFilter resource as an annotation's value.
+type ownerRateLimitPolicies []string
+
+// finalizeEnvoyFilters makes sure orphan EnvoyFilter resources are not left when deleting the owner RateLimitPolicy.
+func (r *RateLimitPolicyReconciler) finalizeEnvoyFilters(ctx context.Context, rlp *apimv1alpha1.RateLimitPolicy) error {
+	logger := logr.FromContext(ctx)
+	logger.Info("Removing/Updating EnvoyFilter resources")
+	ownerRlp := client.ObjectKeyFromObject(rlp).String()
+
+	for _, networkingRef := range rlp.Spec.NetworkingRef {
+		switch networkingRef.Type {
+		case apimv1alpha1.NetworkingRefType_HR:
+			logger.Info("HTTPRoute is not implemented yet") // TODO(rahulanand16nov)
+			continue
+		case apimv1alpha1.NetworkingRefType_VS:
+			logger.Info("Removing/Updating EnvoyFilter resources using VirtualService")
+			vs := istio.VirtualService{}
+			vsKey := client.ObjectKey{Namespace: rlp.Namespace, Name: networkingRef.Name}
+
+			if err := r.Client().Get(ctx, vsKey, &vs); err != nil {
+				logger.Error(err, "failed to get VirutalService")
+				return err
+			}
+
+			for _, gateway := range vs.Spec.Gateways {
+				gwKey := common.NamespacedNameToObjectKey(gateway, vs.Namespace)
+
+				filtersPatchkey := client.ObjectKey{
+					Namespace: gwKey.Namespace,
+					Name:      rlFiltersPatchName(gwKey.Name),
+				}
+				filtersPatch := &istio.EnvoyFilter{}
+				if err := r.Client().Get(ctx, filtersPatchkey, filtersPatch); err != nil {
+					logger.Error(err, "failed to fetch ratelimit filters patch")
+					return err
+				}
+
+				if err := removeOwnerRlpEntry(ctx, r.Client(), filtersPatch, ownerRlp); err != nil {
+					logger.Error(err, "failed to remove ownerRLP tag on filters patch")
+					return err
+				}
+
+				logger.Info("successfully removed ownerRLP entry on the filters patch")
+
+				ratelimitsPatchKey := client.ObjectKey{
+					Namespace: gwKey.Namespace,
+					Name:      ratelimitsPatchName(rlp.Name, gwKey.Name),
+				}
+				ratelimitsPatch := &istio.EnvoyFilter{}
+				if err := r.Client().Get(ctx, ratelimitsPatchKey, ratelimitsPatch); err != nil {
+					logger.Error(err, "failed to fetch ratelimits patch")
+					return err
+				}
+
+				if err := removeOwnerRlpEntry(ctx, r.Client(), ratelimitsPatch, ownerRlp); err != nil {
+					logger.Error(err, "failed to remove ownerRLP tag on ratelimits patch")
+					return err
+				}
+				logger.Info("successfully removed ownerRLP tag on ratelimits patch")
+			}
+		default:
+			return fmt.Errorf(InvalidNetworkingRefTypeErr)
+		}
+	}
+	return nil
+}
+
+func removeOwnerRlpEntry(ctx context.Context, client client.Client, patch *istio.EnvoyFilter, owner string) error {
+	logger := logr.FromContext(ctx)
+	logger.Info("removing ownerRLP entry from EnvoyFilter", "EnvoyFilter", patch.Name)
+
+	// find the annotation
+	ownerRlpsVal, present := patch.Annotations[envoyFilterAnnotationOwnerRLPs]
+	if !present {
+		logger.V(1).Info("Deleting the patch since ownerRLP annotation was not present to avoid orphans")
+		// if it's not deleted then the patch will remain as an orphan once all the rlps are removed.
+		if err := client.Delete(ctx, patch); err != nil {
+			logger.Error(err, "failed to delete the patch")
+			return err
+		}
+		return nil
+	}
+
+	// split into array of RateLimitPolicy names
+	ownerRlps := strings.Split(ownerRlpsVal, ownerRlpSeparator)
+
+	// remove the target owner
+	finalOwnerRlps := []string{}
+	for idx := range ownerRlps {
+		if ownerRlps[idx] == owner {
+			continue
+		}
+		finalOwnerRlps = append(finalOwnerRlps, ownerRlps[idx])
+	}
+
+	if len(finalOwnerRlps) == 0 {
+		logger.V(1).Info("Deleting filters patch because 0 ownerRLP entries found on it")
+		if err := client.Delete(ctx, patch); err != nil {
+			logger.Error(err, "failed to delete the patch")
+			return err
+		}
+	} else {
+		finalOwnerRlpsVal := strings.Join(finalOwnerRlps, ownerRlpSeparator)
+		patch.Annotations[envoyFilterAnnotationOwnerRLPs] = finalOwnerRlpsVal
+		if err := client.Update(ctx, patch); err != nil {
+			logger.Error(err, "failed to update the patch")
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/apim/ratelimitpolicy_finalizers.go
+++ b/controllers/apim/ratelimitpolicy_finalizers.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	filtersFinalizer = "kuadrant.io/ratelimitfilters"
+	patchesFinalizer = "kuadrant.io/ratelimitpatches"
 
 	ownerRlpSeparator = ","
 

--- a/controllers/apim/utils.go
+++ b/controllers/apim/utils.go
@@ -17,7 +17,7 @@ func gatewayLabels(ctx context.Context, client client.Client, gwKey client.Objec
 	if err := client.Get(ctx, gwKey, gateway); err != nil {
 		return map[string]string{}
 	}
-	return gateway.Labels
+	return gateway.Spec.Selector
 }
 
 // rlFiltersPatchName returns the name of EnvoyFilter adding in rate-limit filters to a gateway.

--- a/controllers/apim/utils.go
+++ b/controllers/apim/utils.go
@@ -1,0 +1,81 @@
+package apim
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kuadrant/limitador-operator/api/v1alpha1"
+	istio "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// gatewayLabels fetches labels of an Istio gateway identified using the given ObjectKey.
+func gatewayLabels(ctx context.Context, client client.Client, gwKey client.ObjectKey) map[string]string {
+	gateway := &istio.Gateway{}
+	if err := client.Get(ctx, gwKey, gateway); err != nil {
+		return map[string]string{}
+	}
+	return gateway.Labels
+}
+
+// rlFiltersPatchName returns the name of EnvoyFilter adding in rate-limit filters to a gateway.
+func rlFiltersPatchName(gatewayName string) string {
+	return gatewayName + "-ratelimit-filters"
+}
+
+// ratelimitsPatchName returns the name of EnvoyFilter adding in ratelimits to a gateway.
+func ratelimitsPatchName(rlpName, gatewayName string) string {
+	return fmt.Sprintf("ratelimits-of-%s-in-%s", rlpName, gatewayName)
+}
+
+// getAuthPolicyName generates the name of an AuthorizationPolicy using VirtualService info.
+func getAuthPolicyName(gwName, vsName string) string {
+	return fmt.Sprintf("on-%s-using-%s", gwName, vsName)
+}
+
+func alwaysUpdateEnvoyPatches(existingObj, desiredObj client.Object) (bool, error) {
+	existing, ok := existingObj.(*istio.EnvoyFilter)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *istio.VirtualService", existingObj)
+	}
+	desired, ok := desiredObj.(*istio.EnvoyFilter)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *istio.VirtualService", desiredObj)
+	}
+
+	existing.Spec = desired.Spec
+	existing.Annotations = desired.Annotations
+	return true, nil
+}
+
+func alwaysUpdateAuthPolicy(existingObj, desiredObj client.Object) (bool, error) {
+	existing, ok := existingObj.(*istiosecurityv1beta1.AuthorizationPolicy)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *istiosecurityv1beta1.AuthorizationPolicy", existingObj)
+	}
+	desired, ok := desiredObj.(*istiosecurityv1beta1.AuthorizationPolicy)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *istiosecurityv1beta1.AuthorizationPolicy", desiredObj)
+	}
+
+	existing.Spec = desired.Spec
+	existing.Annotations = desired.Annotations
+	return true, nil
+}
+
+func alwaysUpdateRateLimit(existingObj, desiredObj client.Object) (bool, error) {
+	existing, ok := existingObj.(*v1alpha1.RateLimit)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1alpha1.RateLimit", existingObj)
+	}
+	desired, ok := desiredObj.(*v1alpha1.RateLimit)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1alpha1.RateLimit", desiredObj)
+	}
+
+	existing.Spec = desired.Spec
+	existing.Annotations = desired.Annotations
+	return true, nil
+}

--- a/examples/toystore/virtualService.yaml
+++ b/examples/toystore/virtualService.yaml
@@ -2,14 +2,13 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: toystore
-  namespace: kuadrant-system
   labels:
     app: toystore
 spec:
   hosts:
     - "*.toystore.com"
   gateways:
-    - kuadrant-gateway
+    - kuadrant-system/kuadrant-gateway
   http:
     - match:
         - name: get-toy

--- a/main.go
+++ b/main.go
@@ -40,6 +40,9 @@ import (
 	"github.com/kuadrant/kuadrant-controller/pkg/log"
 	"github.com/kuadrant/kuadrant-controller/pkg/reconcilers"
 	"github.com/kuadrant/kuadrant-controller/version"
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -53,6 +56,9 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(apimv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(istionetworkingv1alpha3.AddToScheme(scheme))
+	utilruntime.Must(istiosecurityv1beta1.AddToScheme(scheme))
+	utilruntime.Must(limitadorv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 
 	logger := log.NewLogger(

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -19,6 +19,9 @@ package common
 import (
 	"fmt"
 	"os"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //TODO: move the const to a proper place, or get it from config
@@ -39,4 +42,23 @@ func FetchEnv(key string, def string) string {
 	}
 
 	return val
+}
+
+// NamespacedNameToObjectKey converts <namespace/name> format string to k8s object key.
+// It's common for K8s to reference an object using this format. For e.g. gateways in VirtualService.
+func NamespacedNameToObjectKey(namespacedName, defaultNamespace string) client.ObjectKey {
+	split := strings.Split(namespacedName, "/")
+	if len(split) == 2 {
+		return client.ObjectKey{Name: split[1], Namespace: split[0]}
+	}
+	return client.ObjectKey{Namespace: defaultNamespace, Name: split[0]}
+}
+
+func Contains(slice []string, target string) bool {
+	for idx := range slice {
+		if slice[idx] == target {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/common/istio_utils.go
+++ b/pkg/common/istio_utils.go
@@ -21,9 +21,14 @@ type EnvoyFilterFactory struct {
 	ObjectName string
 	Namespace  string
 	Patches    []*istioapiv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch
+	Labels     map[string]string
 }
 
 func (v *EnvoyFilterFactory) EnvoyFilter() *istionetworkingv1alpha3.EnvoyFilter {
+	if len(v.Labels) == 0 {
+		// default to kuadrant labels to avoid replication where it's already used.
+		v.Labels = map[string]string{"istio": "kuadrant-system"}
+	}
 	return &istionetworkingv1alpha3.EnvoyFilter{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "EnvoyFilter",
@@ -35,7 +40,7 @@ func (v *EnvoyFilterFactory) EnvoyFilter() *istionetworkingv1alpha3.EnvoyFilter 
 		},
 		Spec: istioapiv1alpha3.EnvoyFilter{
 			WorkloadSelector: &istioapiv1alpha3.WorkloadSelector{
-				Labels: map[string]string{"istio": "kuadrant-system"},
+				Labels: v.Labels,
 			},
 			ConfigPatches: v.Patches,
 		},


### PR DESCRIPTION
This PR adds the following changes:
1. Adds uniqueness requirement on networking refs. This means you cannot add duplicate networking refs of the same type but can with different types (VirtualService and HTTPRoute).
2. Registers Istio types because they were removed in the last PR and caused the controller to stop working.
3. Moves away from using `ownerRefs` on EnvoyFilter resources to using annotation to keep track of dependent RateLimitPolcies. This change was required because it was constraining us to only create resources in the gateway's namespace, which we don't want. This allows us to have VirtualService/RateLimitPolicy in any namespace, but EnvoyFilter patches will be created only in the relevant gateway's namespace.
4. Combines all the ratelimits patches into just one resource for easy management and simpler reconcile logic.
5. Passes labels of the gateways to the `EnvoyFilter` resources which allows flexibility to the constraints mentioned in the change `4`.
6. Uses finalizers to account for the `3` change. This means removing `ownerRLP` entries and if none are present, delete the patch itself.
7. Refactors for simplicity and code reuse.
8. Makes AuthPolicy per-gateway into the gateway's namespace.

## Verification steps
### Initial steps
The following steps are common for all the verifying subsections.
1. `make local-setup`
2. `k apply -f examples/toystore/toystore.yaml`
3. `k apply -f examples/toystore/virtualService.yaml`

#### Verify change `1`
Following command should fail with the error: `The RateLimitPolicy "ratelimitpolicy" is invalid: spec.networkingRef[1]: Duplicate value: map[string]interface {}{"name":"toystore", "type":"VirtualService"}
`
```yaml
k apply -f -<<EOF
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: ratelimitpolicy
spec:
  networkingRef:
    - type: VirtualService
      name: toystore
    - type: VirtualService
      name: toystore
EOF
```

#### Verify change `3`, `4` and `5`
```yaml
k apply -f -<<EOF
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: ratelimitpolicy-1
spec:
  networkingRef:
    - type: VirtualService
      name: toystore
  routes:
    - name: add-toy
      stage: POSTAUTH
      actions:
        - generic_key:
            descriptor_key: admin
            descriptor_value: "yes"
  limits:
    - conditions: ["admin == yes"]
      max_value: 2
      namespace: postauth
      seconds: 15
      variables: []
EOF
```
```yaml
k apply -f -<<EOF
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: ratelimitpolicy-2
spec:
  networkingRef:
    - type: VirtualService
      name: toystore
  routes:
    - name: get-toy
      stage: BOTH
      actions:
        - generic_key:
            descriptor_key: get
            descriptor_value: "yes"
  limits:
    - conditions: ["get == yes"]
      max_value: 2
      namespace: preauth
      seconds: 15
      variables: []
EOF
```
These commands create two `RateLimit` resources and three `EnvoyFilter` (one for filters and two for ratelimits) resources with `kuadrant.io/ownerRateLimitPolicies: default/ratelimitpolicy-1,default/ratelimitpolicy-2` annotation. Notice that those two values refer to the RLPs you just created. Plus, now there is only one ratelimit patch per RLP and they can be created even if RLP is in a different namespace to that of gateways.

#### Verify change `6`
This piggybacks onto the last verification section.
```
k delete ratelimitpolicy ratelimitpolicy-1
```
Check patches to see that the `ownerRLP` entry and one of ratelimits patch is removed.
```
k delete ratelimitpolicy ratelimitpolicy-2
```
This should remove all the `EnvoyFilter` resources that were created in the last section.

#### Verify change `8`
Add the `kuadrant.io/auth-provider: kuadrant-authorization` annotation to the VirtualService added in the initial step.
```
k get authorizationpolicy -A
```
This command will show the authpolicy in the gateway's namespace even though VirtualService is in `default` namespace.