### PR TITLE
fix ratelimit namespace and handle deletion of rl policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ istio-manifest-update-test: generate-istio-manifests
 
 .PHONY: local-setup
 local-setup: local-cleanup local-setup-kind manifests kustomize generate
-	./utils/local-deployment/local-setup.sh
+	export PATH=$(PROJECT_PATH)/bin:$$PATH;	./utils/local-deployment/local-setup.sh
 
 # Deploys all services and manifests required by kuadrant to run
 # kuadrant is not deployed

--- a/controllers/apim/utils.go
+++ b/controllers/apim/utils.go
@@ -31,6 +31,11 @@ func ratelimitsPatchName(gwName string, networkKey client.ObjectKey) string {
 	return fmt.Sprintf("ratelimits-on-%s-using-%s-%s", gwName, networkKey.Namespace, networkKey.Name)
 }
 
+// limitadorRatelimitsName returns the name of Limitador RateLimit CR.
+func limitadorRatelimitsName(objKey client.ObjectKey, idx int) string {
+	return fmt.Sprintf("%s-%s-%d", objKey.Namespace, objKey.Name, idx)
+}
+
 // getAuthPolicyName generates the name of an AuthorizationPolicy using VirtualService info.
 func getAuthPolicyName(gwName, vsName string) string {
 	return fmt.Sprintf("on-%s-using-%s", gwName, vsName)

--- a/controllers/apim/utils.go
+++ b/controllers/apim/utils.go
@@ -33,7 +33,7 @@ func ratelimitsPatchName(gwName string, networkKey client.ObjectKey) string {
 
 // limitadorRatelimitsName returns the name of Limitador RateLimit CR.
 func limitadorRatelimitsName(objKey client.ObjectKey, idx int) string {
-	return fmt.Sprintf("%s-%s-%d", objKey.Namespace, objKey.Name, idx)
+	return fmt.Sprintf("rlp-%s-%s-%d", objKey.Namespace, objKey.Name, idx)
 }
 
 // getAuthPolicyName generates the name of an AuthorizationPolicy using VirtualService info.


### PR DESCRIPTION
* Limitador RateLimit CRs created in the namespace of the limitador service instead of the RateLimitPolicy namespace.

The limitador operator applies rate limit CR configuration on the limitador service running in the same namespace of the CR

* Delete RateLimit CRs when RateLimitPolicy is deleted

# Verification steps

1. `make local-setup`
2. Deploy toystore ratelimitpolicy in `default` namespace
`k apply -f examples/toystore`

The kuadrant controller should have created ratelimit objects in the same namespace as the limitador service, i.e. `kuadrant-system`

```
$ k get ratelimits -A
NAMESPACE         NAME                 AGE
kuadrant-system   default-toystore-1   7s
kuadrant-system   default-toystore-2   7s
```
3. Remove the rate limit policy
```
k delete ratelimitpolicy toystore
```
Check that ratelimit CRs are also deleted

```
$ k get ratelimits -A
No resources found.
```
  


