### PR TITLE
increase duration and add postauth limit

### DIFF
--- a/config/samples/apim_v1alpha1_ratelimitpolicy.yaml
+++ b/config/samples/apim_v1alpha1_ratelimitpolicy.yaml
@@ -39,10 +39,15 @@ spec:
     - conditions: ["get-toy == yes"]
       max_value: 2
       namespace: preauth
-      seconds: 15
+      seconds: 30
       variables: []
-    - condtitions: ["vhaction == yes"]
-      max_value: 4
+    - conditions: ["add-toy == yes"]
+      max_value: 2
+      namespace: postauth
+      seconds: 30
+      variables: []
+    - conditions: ["vhaction == yes"]
+      max_value: 6
       namespace: preauth
-      seconds: 15
+      seconds: 30
       variables: []

--- a/examples/toystore/ratelimitpolicy.yaml
+++ b/examples/toystore/ratelimitpolicy.yaml
@@ -39,10 +39,15 @@ spec:
     - conditions: ["get-toy == yes"]
       max_value: 2
       namespace: preauth
-      seconds: 15
+      seconds: 30
+      variables: []
+    - conditions: ["add-toy == yes"]
+      max_value: 2
+      namespace: postauth
+      seconds: 30
       variables: []
     - conditions: ["vhaction == yes"]
-      max_value: 4
+      max_value: 6
       namespace: preauth
-      seconds: 15
+      seconds: 30
       variables: []


### PR DESCRIPTION
This PR:
- Increases example RLP expiration time to 30 seconds
- Adds postauth limit for testing/demo.