### PR TITLE
fix envoyfilter for ratelimit action

### DIFF
--- a/controllers/apim/ratelimitpolicy_controller.go
+++ b/controllers/apim/ratelimitpolicy_controller.go
@@ -480,7 +480,7 @@ func routeRateLimitsPatch(vHostName string, routeName string, rateLimits []*apim
 					Vhost: &networkingv1alpha3.EnvoyFilter_RouteConfigurationMatch_VirtualHostMatch{
 						Name: vHostName,
 						Route: &networkingv1alpha3.EnvoyFilter_RouteConfigurationMatch_RouteMatch{
-							Name: "." + routeName, // Istio adds '.' infront of names
+							Name: routeName,
 						},
 					},
 				},

--- a/examples/toystore/httproute.yaml
+++ b/examples/toystore/httproute.yaml
@@ -13,7 +13,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: "toy"
+            value: "/toy"
           method: GET
         - path:
             type: Exact

--- a/examples/toystore/virtualService.yaml
+++ b/examples/toystore/virtualService.yaml
@@ -11,24 +11,36 @@ spec:
   gateways:
     - kuadrant-system/kuadrant-gateway
   http:
-    - match:
-        - name: get-toy
-          uri:
+    - name: get-toy
+      match:
+        - uri:
             exact: /toy
           method:
             exact: GET
-        - name: add-toy
-          uri:
+      route:
+        - destination:
+            host: toystore.default.svc
+            port:
+              number: 80
+    - name: add-toy
+      match:
+        - uri:
             exact: /admin/toy
           method:
             exact: POST
-        - name: delete-toy
-          uri:
+      route:
+        - destination:
+            host: toystore.default.svc
+            port:
+              number: 80
+    - name: delete-toy
+      match:
+        - uri:
             exact: /admin/toy
           method:
             exact: DELETE
       route:
         - destination:
-            host: toystore.default.svc.cluster.local
+            host: toystore.default.svc
             port:
               number: 80


### PR DESCRIPTION
## What

The EnvoyFilter to add rate limits actions configuration at the route level was adding a trailing dot `.`. 

## Why 

Istio does not add any trailing dot `.` for the route name. 

Istio adds a route for each match ([HTTPMatchRequest](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest). The route name (in envoy's virtualhost route) will `${routeName}.{matchName}`.

For a virtualservice like this without a route name (only match name):
```yaml
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: toystore
  labels:
    app: toystore
spec:
  hosts:
    - "*.toystore.com"
  gateways:
    - kuadrant-system/kuadrant-gateway
  http:
    - match:
        - name: get-toy
          uri:
            exact: /toy
          method:
            exact: GET
      route:
        - destination:
            host: toystore.default.svc.cluster.local
            port:
              number: 80
```

The ratelimitpolicy should be like this (`.get-toy`):
```yaml
---
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  routes:
    - name: ".get-toy"
      rateLimits:
        - stage: BOTH
          actions:
            - generic_key:
                descriptor_key: get-toy
                descriptor_value: "yes"
```
