### PR TITLE
Update apim_v1alpha1_ratelimitpolicy.yaml

### DIFF
--- a/config/samples/apim_v1alpha1_ratelimitpolicy.yaml
+++ b/config/samples/apim_v1alpha1_ratelimitpolicy.yaml
@@ -8,7 +8,6 @@ spec:
     - operations:
         - paths: ["/toy"]
           methods: ["GET"]
-          hosts: ["*.toystore.com"]
       rateLimits:
         - stage: BOTH
           actions:


### PR DESCRIPTION
removing the host from the sample. I want to link to this example so don't want to show a host there currently. There maybe a place for it in the future but which hosts can be added there should be governed/restricted by the targeted resource 