### PR TITLE
move hosts to top-level object and update istio version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ kind: ## Download kind locally if necessary.
 
 # istioctl tool
 ISTIOCTL=$(PROJECT_PATH)/bin/istioctl
-ISTIOVERSION = 1.12.1
+ISTIOVERSION = 1.12.2
 $(ISTIOCTL):
 	mkdir -p $(PROJECT_PATH)/bin
 	$(eval TMP := $(shell mktemp -d))

--- a/apis/apim/v1alpha1/ratelimitpolicy_types.go
+++ b/apis/apim/v1alpha1/ratelimitpolicy_types.go
@@ -108,11 +108,6 @@ type Operation struct {
 }
 
 type Rule struct {
-	// Name supports regex for fetching operations from routing resources
-	// For VirtualService, if route name matches, all the match requests are
-	// converted to operations internally. But specific match request names
-	// are also supported.
-	Name string `json:"name,omitempty"`
 	// Operation specifies the operations of a request
 	// +optional
 	Operations []*Operation `json:"operations,omitempty"`

--- a/config/crd/bases/apim.kuadrant.io_ratelimitpolicies.yaml
+++ b/config/crd/bases/apim.kuadrant.io_ratelimitpolicies.yaml
@@ -149,12 +149,6 @@ spec:
               rules:
                 items:
                   properties:
-                    name:
-                      description: Name supports regex for fetching operations from
-                        routing resources For VirtualService, if route name matches,
-                        all the match requests are converted to operations internally.
-                        But specific match request names are also supported.
-                      type: string
                     operations:
                       description: Operation specifies the operations of a request
                       items:

--- a/config/deploy/manifests.yaml
+++ b/config/deploy/manifests.yaml
@@ -158,9 +158,6 @@ spec:
               rules:
                 items:
                   properties:
-                    name:
-                      description: Name supports regex for fetching operations from routing resources For VirtualService, if route name matches, all the match requests are converted to operations internally. But specific match request names are also supported.
-                      type: string
                     operations:
                       description: Operation specifies the operations of a request
                       items:

--- a/pkg/istio/wasm.go
+++ b/pkg/istio/wasm.go
@@ -11,6 +11,7 @@ type Rule struct {
 }
 
 type PluginPolicy struct {
+	Hosts           []string                        `json:"hosts,omitempty"`
 	Rules           []*Rule                         `json:"rules"`
 	GlobalActions   []*apimv1alpha1.ActionSpecifier `json:"global_actions,omitempty"`
 	UpstreamCluster string                          `json:"upstream_cluster"`
@@ -22,8 +23,10 @@ type PluginConfig struct {
 	PluginPolicies  map[string]PluginPolicy `json:"ratelimitpolicies"`
 }
 
-func PluginPolicyFromRateLimitPolicy(rlp *apimv1alpha1.RateLimitPolicy, pluginStage apimv1alpha1.RateLimitStage) *PluginPolicy {
-	pluginPolicy := &PluginPolicy{}
+func PluginPolicyFromRateLimitPolicy(rlp *apimv1alpha1.RateLimitPolicy, hosts []string, pluginStage apimv1alpha1.RateLimitStage) *PluginPolicy {
+	pluginPolicy := &PluginPolicy{
+		Hosts: hosts,
+	}
 
 	// Filter through global ratelimits
 	for _, ratelimit := range rlp.Spec.RateLimits {

--- a/utils/local-deployment/istio-manifests/autogenerated/Base/Base.yaml
+++ b/utils/local-deployment/istio-manifests/autogenerated/Base/Base.yaml
@@ -5942,8 +5942,7 @@ spec:
                   type: object
                 type: array
               selector:
-                description: The selector determines the workloads to apply the RequestAuthentication
-                  on.
+                description: Optional.
                 properties:
                   matchLabels:
                     additionalProperties:

--- a/utils/local-deployment/istio-manifests/autogenerated/Base/Pilot/IngressGateways/IngressGateways.yaml
+++ b/utils/local-deployment/istio-manifests/autogenerated/Base/Pilot/IngressGateways/IngressGateways.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: kuadrant-gateway-service-account
       containers:
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.12.1"
+          image: "docker.io/istio/proxyv2:1.12.2"
           ports:
             - containerPort: 15021
               protocol: TCP

--- a/utils/local-deployment/istio-manifests/autogenerated/Base/Pilot/Pilot.yaml
+++ b/utils/local-deployment/istio-manifests/autogenerated/Base/Pilot/Pilot.yaml
@@ -235,7 +235,7 @@ spec:
         fsGroup: 1337
       containers:
         - name: discovery
-          image: "docker.io/istio/pilot:1.12.1"
+          image: "docker.io/istio/pilot:1.12.2"
           args:
           - "discovery"
           - --monitoringAddr=:15014
@@ -452,7 +452,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.12.1",
+        "tag": "1.12.2",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -528,7 +528,7 @@ data:
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
-            traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` .Values.global.proxy.includeInboundPorts }}traffic.sidecar.istio.io/includeInboundPorts: "{{.}}",{{ end }}
             traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
             {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
             traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
@@ -568,7 +568,7 @@ data:
             - "-x"
             - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
             - "-b"
-            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` .Values.global.proxy.includeInboundPorts }}"
             - "-d"
           {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
             - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"


### PR DESCRIPTION
This PR:
- Moves hosts from `operation` level to `pluginconfig` level. This fixes a bug that left out virtual host rate limits if there wasn't any route-based rate limit match.
- Updates Istio version to `1.12.2`

## Verification steps:
Shown in the demo protecting Apicurio Registry using HTTPRoute.