### PR TITLE
rlp: validate httproute target is accepted

### DIFF
--- a/controllers/apim/ratelimitpolicy_controller.go
+++ b/controllers/apim/ratelimitpolicy_controller.go
@@ -373,7 +373,6 @@ func (r *RateLimitPolicyReconciler) validateHTTPRoute(ctx context.Context, rlp *
 	// Check HTTProute parents (gateways) in the status object
 	// if any of the current parent gateways reports not "Admitted", return error
 	for _, parentRef := range httpRoute.Spec.CommonRouteSpec.ParentRefs {
-
 		routeParentStatus := func(pRef gatewayapiv1alpha2.ParentRef) *gatewayapiv1alpha2.RouteParentStatus {
 			for idx := range httpRoute.Status.RouteStatus.Parents {
 				if reflect.DeepEqual(pRef, httpRoute.Status.RouteStatus.Parents[idx].ParentRef) {

--- a/controllers/apim/ratelimitpolicy_controller.go
+++ b/controllers/apim/ratelimitpolicy_controller.go
@@ -18,12 +18,15 @@ package apim
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	"github.com/kuadrant/limitador-operator/api/v1alpha1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -136,6 +139,11 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 
 func (r *RateLimitPolicyReconciler) reconcileSpec(ctx context.Context, rlp *apimv1alpha1.RateLimitPolicy) (ctrl.Result, error) {
 	err := rlp.Validate()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.validateHTTPRoute(ctx, rlp)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -353,6 +361,39 @@ func (r *RateLimitPolicyReconciler) gatewayRefList(ctx context.Context, rlp *api
 	}
 
 	return gwKeys, nil
+}
+
+func (r *RateLimitPolicyReconciler) validateHTTPRoute(ctx context.Context, rlp *apimv1alpha1.RateLimitPolicy) error {
+	httpRoute, err := r.fetchHTTPRoute(ctx, rlp)
+	if err != nil {
+		// The object should exist
+		return err
+	}
+
+	// Check HTTProute parents (gateways) in the status object
+	// if any of the current parent gateways reports not "Admitted", return error
+	for _, parentRef := range httpRoute.Spec.CommonRouteSpec.ParentRefs {
+
+		routeParentStatus := func(pRef gatewayapiv1alpha2.ParentRef) *gatewayapiv1alpha2.RouteParentStatus {
+			for idx := range httpRoute.Status.RouteStatus.Parents {
+				if reflect.DeepEqual(pRef, httpRoute.Status.RouteStatus.Parents[idx].ParentRef) {
+					return &httpRoute.Status.RouteStatus.Parents[idx]
+				}
+			}
+
+			return nil
+		}(parentRef)
+
+		if routeParentStatus == nil {
+			continue
+		}
+
+		if meta.IsStatusConditionFalse(routeParentStatus.Conditions, "Accepted") {
+			return errors.New("httproute not accepted")
+		}
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
### what
The controller validates that targetref from the RateLimitPolicy are `Accepted` HTTPRoutes. Otherwise, update `.status` object and retry.

### verification steps

Deploy gateway with `hostname` in the listener:
```yaml
k apply -f - <<EOF
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: Gateway
metadata:
  labels:
    istio: kuadrant-system
  name: kuadrant-gwapi-gateway
  namespace: kuadrant-system
spec:
  gatewayClassName: istio
  listeners:
  - name: default
    hostname: "*.toystore.com"
    port: 80
    protocol: HTTP
    allowedRoutes:
      namespaces:
        from: All
  addresses:
  - value: kuadrant-gateway.kuadrant-system.svc.cluster.local
    type: Hostname
EOF
```

Deploy HTTPRoute with  a hostname not matching the  previous gateway's hostname. It should not be accepted.

```yaml
k apply -f - <<EOF
--
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: carstore
  labels:
    app: carstore
spec:
  parentRefs:
    - name: kuadrant-gwapi-gateway
      namespace: kuadrant-system
  hostnames: ["*.carstore.com"]
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/car"
          method: GET
      backendRefs:
        - name: carstore
          port: 80
EOF
```
 It should not be accepted.
```yaml
k get httproutes.gateway.networking.k8s.io  carstore -o jsonpath='{.status}' | yq e -P
parents:
  - conditions:
      - lastTransitionTime: "2022-04-25T14:32:44Z"
        message: no hostnames matched parent hostname "*.toystore.com"
        observedGeneration: 1
        reason: InvalidParentReference
        status: "False"
        type: Accepted
    controllerName: istio.io/gateway-controller
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: kuadrant-gwapi-gateway
      namespace: kuadrant-system
```

Deploy RLP targeting the HTTPRoute:

```yaml
k apply -f - <<EOF
---
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: carstore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: carstore
  rules:
    - operations:
        - paths: ["/car"]
          methods: ["GET"]
      rateLimits:
        - stage: PREAUTH
          actions:
            - generic_key:
                descriptor_key: get-car
                descriptor_value: "yes"
  domain: carstore-app
  limits:
    - conditions: ["get-car== yes"]
      max_value: 2
      namespace: carstore-app
      seconds: 30
      variables: []
EOF
```

The status of the RLP should report as not available:

```yaml
k get ratelimitpolicy carstore -o jsonpath='{.status}' | yq e -P
conditions:
  - lastTransitionTime: "2022-04-25T14:44:55Z"
    message: httproute not accepted
    reason: ReconcilliationError
    status: "False"
    type: Available
observedGeneration: 1
```

