### PR TITLE
enforce hierarchical constraints on hostnames

### DIFF
--- a/controllers/apim/authpolicy_controller.go
+++ b/controllers/apim/authpolicy_controller.go
@@ -164,7 +164,7 @@ func (r *AuthPolicyReconciler) enforceHierarchicalConstraints(ctx context.Contex
 				}
 			}
 			if !isSubsetHost {
-				return fmt.Errorf("rule #%d host '%s' doesn't follow any hierarchical constraints", ruleIdx+1, host)
+				return fmt.Errorf("rule #%d host (%s) does not follow any hierarchical constraints", ruleIdx+1, host)
 			}
 		}
 	}
@@ -178,7 +178,7 @@ func (r *AuthPolicyReconciler) enforceHierarchicalConstraints(ctx context.Contex
 			}
 		}
 		if !isSubsetHost {
-			return fmt.Errorf("host defined in hostnames '%s' doesn't follow any hierarchical constraints", host)
+			return fmt.Errorf("host defined in authscheme (%s) does not follow any hierarchical constraints", host)
 		}
 	}
 	return nil
@@ -202,12 +202,6 @@ func (r *AuthPolicyReconciler) reconcileAuthSchemes(ctx context.Context, ap *api
 	}
 
 	return nil
-}
-
-func PrefixHostsConstraint(obj client.Object) []string {
-
-	// obj is a gateway resource with no prefix constraint
-	return []string{""}
 }
 
 // reconcileAuthRules translates and reconciles `AuthRules` into an Istio AuthorizationPoilcy containing them.

--- a/controllers/apim/authpolicy_controller.go
+++ b/controllers/apim/authpolicy_controller.go
@@ -3,6 +3,7 @@ package apim
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	authorinov1beta1 "github.com/kuadrant/authorino/api/v1beta1"
@@ -114,6 +115,10 @@ func (r *AuthPolicyReconciler) reconcileSpec(ctx context.Context, ap *apimv1alph
 		return ctrl.Result{}, err
 	}
 
+	if err := r.enforceHierarchicalConstraints(ctx, ap); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if err := r.reconcileNetworkResourceBackReference(ctx, ap); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -127,6 +132,56 @@ func (r *AuthPolicyReconciler) reconcileSpec(ctx context.Context, ap *apimv1alph
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *AuthPolicyReconciler) enforceHierarchicalConstraints(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
+	targetObj, err := r.fetchTargetObject(ctx, ap)
+	if err != nil {
+		return err
+	}
+
+	constrainingHosts := []string{}
+	if hr, isHR := targetObj.(*gatewayapiv1alpha2.HTTPRoute); isHR {
+		hostnames := HostnamesToStrings(hr.Spec.Hostnames)
+		for idx := range hostnames {
+			if len(hostnames[idx]) != 0 && hostnames[idx][0] == '*' {
+				// Follows https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2.Hostname
+				trimmedHost := strings.Trim(hostnames[idx], "*.")
+				constrainingHosts = append(constrainingHosts, trimmedHost)
+			} else {
+				constrainingHosts = append(constrainingHosts, hostnames[idx])
+			}
+		}
+	}
+
+	for ruleIdx, rule := range ap.Spec.AuthRules {
+		for _, host := range rule.Hosts {
+			isSubsetHost := false
+			for _, constraint := range constrainingHosts {
+				if strings.HasSuffix(host, constraint) {
+					isSubsetHost = true
+					break
+				}
+			}
+			if !isSubsetHost {
+				return fmt.Errorf("rule #%d host '%s' doesn't follow any hierarchical constraints", ruleIdx+1, host)
+			}
+		}
+	}
+
+	for _, host := range ap.Spec.AuthScheme.Hosts {
+		isSubsetHost := false
+		for _, constraint := range constrainingHosts {
+			if strings.HasSuffix(host, constraint) {
+				isSubsetHost = true
+				break
+			}
+		}
+		if !isSubsetHost {
+			return fmt.Errorf("host defined in hostnames '%s' doesn't follow any hierarchical constraints", host)
+		}
+	}
+	return nil
 }
 
 func (r *AuthPolicyReconciler) reconcileAuthSchemes(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
@@ -147,6 +202,12 @@ func (r *AuthPolicyReconciler) reconcileAuthSchemes(ctx context.Context, ap *api
 	}
 
 	return nil
+}
+
+func PrefixHostsConstraint(obj client.Object) []string {
+
+	// obj is a gateway resource with no prefix constraint
+	return []string{""}
 }
 
 // reconcileAuthRules translates and reconciles `AuthRules` into an Istio AuthorizationPoilcy containing them.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.2.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
+	github.com/google/uuid v1.1.2
 	github.com/kuadrant/authorino v0.8.0
 	github.com/kuadrant/limitador-operator v0.2.0
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
#181 

## Verification Steps
```
kubectl apply -f - <<EOF
---
apiVersion: apim.kuadrant.io/v1alpha1
kind: AuthPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
  - hosts: ["*.appstore.com"]
    methods: ["DELETE", "POST"]
    paths: ["/admin*"]
  authScheme:
    hosts: ["api.appstore.com"]
    identity:
    - name: apikey
      apiKey:
        labelSelectors:
          app: toystore
      credentials:
        in: authorization_header
        keySelector: APIKEY
EOF
```
Status:
```
status:
  conditions:
  - lastTransitionTime: "2022-07-13T09:20:27Z"
    message: 'rule #1 host ''*.appstore.com'' doesn''t follow any hierarchical constraints'
    reason: ReconciliationError
    status: "False"
    type: Available
  observedGeneration: 1
```

Edit the `appstore.com` to `toystore.com` and status will change to following.
```
status:
  conditions:
  - lastTransitionTime: "2022-07-13T09:27:28Z"
    message: HTTPRoute is protected
    reason: HTTPRouteProtected
    status: "True"
    type: Available
  observedGeneration: 3
```