### PR TITLE
RLP controller: Fix gateway not found

### DIFF
--- a/apis/apim/v1alpha1/authpolicy_types.go
+++ b/apis/apim/v1alpha1/authpolicy_types.go
@@ -40,8 +40,8 @@ type AuthPolicyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 type AuthPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/apim/v1alpha1/common.go
+++ b/apis/apim/v1alpha1/common.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Interface to be implemented by Policy's status struct
-//+kubebuilder:object:generate=false
+// +kubebuilder:object:generate=false
 type PolicyStatus interface {
 	GetObservedGeneration() int64
 	GetConditions() []metav1.Condition

--- a/apis/apim/v1alpha1/groupversion_info.go
+++ b/apis/apim/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the apim v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=apim.kuadrant.io
+// +kubebuilder:object:generate=true
+// +groupName=apim.kuadrant.io
 package v1alpha1
 
 import (

--- a/controllers/apim/ratelimitpolicy_finalizers.go
+++ b/controllers/apim/ratelimitpolicy_finalizers.go
@@ -75,6 +75,9 @@ func (r *RateLimitPolicyReconciler) computeFinalizeGatewayDiff(ctx context.Conte
 		err := r.Client().Get(ctx, gwKey, gw)
 		logger.V(1).Info("finalizeRLP", "fetch gateway", gwKey, "err", err)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return nil, err
 		}
 		gwDiff.LeftGateways = append(gwDiff.LeftGateways, rlptools.GatewayWrapper{Gateway: gw})

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//TODO: move the const to a proper place, or get it from config
+// TODO: move the const to a proper place, or get it from config
 const (
 	KuadrantNamespace                    = "kuadrant-system"
 	KuadrantAuthorizationProvider        = "kuadrant-authorization"

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -97,8 +97,10 @@ func (b *BaseReconciler) EventRecorder() record.EventRecorder {
 // with the existing state inside the passed in callback MutateFn.
 //
 // obj: Object of the same type as the 'desired' object.
-//            Used to read the resource from the kubernetes cluster.
-//            Could be zero-valued initialized object.
+//
+//	Used to read the resource from the kubernetes cluster.
+//	Could be zero-valued initialized object.
+//
 // desired: Object representing the desired state
 //
 // It returns an error.
@@ -166,7 +168,7 @@ func (b *BaseReconciler) UpdateResourceStatus(ctx context.Context, obj client.Ob
 	return b.Client().Status().Update(ctx, obj)
 }
 
-//SetOwnerReference sets owner as a Controller OwnerReference on owned
+// SetOwnerReference sets owner as a Controller OwnerReference on owned
 func (b *BaseReconciler) SetOwnerReference(owner, obj client.Object) error {
 	err := controllerutil.SetControllerReference(owner, obj, b.Scheme())
 	if err != nil {
@@ -179,7 +181,7 @@ func (b *BaseReconciler) SetOwnerReference(owner, obj client.Object) error {
 	return err
 }
 
-//EnsureOwnerReference sets owner as a Controller OwnerReference on owned
+// EnsureOwnerReference sets owner as a Controller OwnerReference on owned
 // returns boolean to notify when the object has been updated
 func (b *BaseReconciler) EnsureOwnerReference(owner, obj client.Object) (bool, error) {
 	changed := false

--- a/pkg/rlptools/limitador_utils.go
+++ b/pkg/rlptools/limitador_utils.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kuadrant/kuadrant-controller/pkg/common"
 )
 
-//TODO: we might want to have every single ENV in the same file
+// TODO: we might want to have every single ENV in the same file
 var (
 	LimitadorNamespace = common.FetchEnv("LIMITADOR_NAMESPACE", common.KuadrantNamespace)
 	LimitadorName      = common.FetchEnv("LIMITADOR_NAME", "limitador")


### PR DESCRIPTION
### what
the RLP controller handles when a referenced gateway does not exist. However, the finalizer part of the controller (the code that handles the cleaning up of resources when the RLP is deleted) did not handle correctly when a gateway did not exist. This PR, fixes that. Without the fix, the controller could not remove the finalizer in the CR and the deletion of the CR was blocked. 

### verification steps
Deploy the kuadrant controller

```
make local-setup
```

Create RLP with broken gateway reference

```yaml
k apply -f - <<EOF
---
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: global-settings
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: not-existing-name
  rateLimits:
    - configurations:
        - actions:
            - generic_key:
                descriptor_key: global-traffic
                descriptor_value: "1"
      limits:
        - conditions:
            - "global-traffic == 1"
          maxValue: 100
          seconds: 10
          variables: []
EOF
```
Delete the rlp. The deletion should not be blocked

```
k delete ratelimitpolicy global-settings
```
