### PR TITLE
support gateways RLPs alone

### DIFF
--- a/apis/apim/v1alpha1/ratelimitpolicy_types.go
+++ b/apis/apim/v1alpha1/ratelimitpolicy_types.go
@@ -241,6 +241,17 @@ func (r *RateLimitPolicy) TargetKey() client.ObjectKey {
 	}
 }
 
+// FlattenLimits returns Limit list from RateLimit list
+func (r *RateLimitPolicy) FlattenLimits() []Limit {
+	flattenLimits := make([]Limit, 0)
+
+	for idx := range r.Spec.RateLimits {
+		flattenLimits = append(flattenLimits, r.Spec.RateLimits[idx].Limits...)
+	}
+
+	return flattenLimits
+}
+
 //+kubebuilder:object:root=true
 
 // RateLimitPolicyList contains a list of RateLimitPolicy

--- a/controllers/apim/ratelimitpolicy_cluster_envoy_filter.go
+++ b/controllers/apim/ratelimitpolicy_cluster_envoy_filter.go
@@ -70,21 +70,6 @@ func (r *RateLimitPolicyReconciler) gatewayRateLimitingClusterEnvoyFilter(
 	gwKey := client.ObjectKeyFromObject(gw)
 	logger.V(1).Info("gatewayRateLimitingClusterEnvoyFilter", "gwKey", gwKey, "rlpRefs", rlpRefs)
 
-	// Load all relevant rate limit policies
-	routeRLPList := make([]*apimv1alpha1.RateLimitPolicy, 0)
-	for _, rlpKey := range rlpRefs {
-		rlp := &apimv1alpha1.RateLimitPolicy{}
-		err := r.Client().Get(ctx, rlpKey, rlp)
-		logger.V(1).Info("gatewayRateLimitingClusterEnvoyFilter", "get rlp", rlpKey, "err", err)
-		if err != nil {
-			return nil, err
-		}
-
-		if rlp.IsForHTTPRoute() {
-			routeRLPList = append(routeRLPList, rlp)
-		}
-	}
-
 	ef := &istioclientnetworkingv1alpha3.EnvoyFilter{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "EnvoyFilter",
@@ -102,7 +87,7 @@ func (r *RateLimitPolicyReconciler) gatewayRateLimitingClusterEnvoyFilter(
 		},
 	}
 
-	if len(routeRLPList) < 1 {
+	if len(rlpRefs) < 1 {
 		common.TagObjectToDelete(ef)
 		return ef, nil
 	}

--- a/controllers/apim/ratelimitpolicy_finalizers.go
+++ b/controllers/apim/ratelimitpolicy_finalizers.go
@@ -65,10 +65,7 @@ func (r *RateLimitPolicyReconciler) computeFinalizeGatewayDiff(ctx context.Conte
 		LeftGateways: nil,
 	}
 
-	var rlpGwKeys []client.ObjectKey
-	var err error
-
-	rlpGwKeys, err = r.rlpGatewayKeys(ctx, rlp)
+	rlpGwKeys, err := r.rlpGatewayKeys(ctx, rlp)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}

--- a/controllers/apim/ratelimitpolicy_finalizers.go
+++ b/controllers/apim/ratelimitpolicy_finalizers.go
@@ -43,7 +43,7 @@ func (r *RateLimitPolicyReconciler) finalizeRLP(ctx context.Context, rlp *apimv1
 		return err
 	}
 
-	if err := r.reconcileLimits(ctx, rlp, gatewayDiffObj); err != nil {
+	if err := r.reconcileLimits(ctx, rlp, gatewayDiffObj); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 
@@ -65,8 +65,11 @@ func (r *RateLimitPolicyReconciler) computeFinalizeGatewayDiff(ctx context.Conte
 		LeftGateways: nil,
 	}
 
-	rlpGwKeys, err := r.rlpGatewayKeys(ctx, rlp)
-	if err != nil {
+	var rlpGwKeys []client.ObjectKey
+	var err error
+
+	rlpGwKeys, err = r.rlpGatewayKeys(ctx, rlp)
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 

--- a/controllers/apim/ratelimitpolicy_wasm_plugins.go
+++ b/controllers/apim/ratelimitpolicy_wasm_plugins.go
@@ -10,7 +10,6 @@ import (
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
 	"github.com/kuadrant/kuadrant-controller/pkg/common"
@@ -29,7 +28,7 @@ func (r *RateLimitPolicyReconciler) reconcileWASMPluginConf(ctx context.Context,
 			// remove index
 			rlpRefs = append(rlpRefs[:refID], rlpRefs[refID+1:]...)
 		}
-		wp, err := r.gatewayWASMPlugin(ctx, leftGateway.Gateway, rlpRefs)
+		wp, err := r.gatewayWASMPlugin(ctx, leftGateway, rlpRefs)
 		if err != nil {
 			return err
 		}
@@ -41,7 +40,7 @@ func (r *RateLimitPolicyReconciler) reconcileWASMPluginConf(ctx context.Context,
 
 	for _, sameGateway := range gwDiffObj.SameGateways {
 		logger.V(1).Info("reconcileWASMPluginConf: same gateways", "gw key", sameGateway.Key())
-		wp, err := r.gatewayWASMPlugin(ctx, sameGateway.Gateway, sameGateway.RLPRefs())
+		wp, err := r.gatewayWASMPlugin(ctx, sameGateway, sameGateway.RLPRefs())
 		if err != nil {
 			return err
 		}
@@ -59,7 +58,7 @@ func (r *RateLimitPolicyReconciler) reconcileWASMPluginConf(ctx context.Context,
 		if !common.ContainsObjectKey(rlpRefs, rlpKey) {
 			rlpRefs = append(newGateway.RLPRefs(), rlpKey)
 		}
-		wp, err := r.gatewayWASMPlugin(ctx, newGateway.Gateway, rlpRefs)
+		wp, err := r.gatewayWASMPlugin(ctx, newGateway, rlpRefs)
 		if err != nil {
 			return err
 		}
@@ -71,9 +70,9 @@ func (r *RateLimitPolicyReconciler) reconcileWASMPluginConf(ctx context.Context,
 	return nil
 }
 
-func (r *RateLimitPolicyReconciler) gatewayWASMPlugin(ctx context.Context, gw *gatewayapiv1alpha2.Gateway, rlpRefs []client.ObjectKey) (*istioclientgoextensionv1alpha1.WasmPlugin, error) {
+func (r *RateLimitPolicyReconciler) gatewayWASMPlugin(ctx context.Context, gw rlptools.GatewayWrapper, rlpRefs []client.ObjectKey) (*istioclientgoextensionv1alpha1.WasmPlugin, error) {
 	logger, _ := logr.FromContext(ctx)
-	logger.V(1).Info("gatewayWASMPlugin", "gwKey", client.ObjectKeyFromObject(gw), "rlpRefs", rlpRefs)
+	logger.V(1).Info("gatewayWASMPlugin", "gwKey", gw.Key(), "rlpRefs", rlpRefs)
 
 	wasmPlugin := &istioclientgoextensionv1alpha1.WasmPlugin{
 		TypeMeta: metav1.TypeMeta{
@@ -93,6 +92,11 @@ func (r *RateLimitPolicyReconciler) gatewayWASMPlugin(ctx context.Context, gw *g
 			// Insert plugin before Istio stats filters and after Istio authorization filters.
 			Phase: istioextensionsv1alpha1.PluginPhase_STATS,
 		},
+	}
+
+	if len(rlpRefs) < 1 {
+		common.TagObjectToDelete(wasmPlugin)
+		return wasmPlugin, nil
 	}
 
 	pluginConfig, err := r.wasmPluginConfig(ctx, gw, rlpRefs)
@@ -116,16 +120,16 @@ func (r *RateLimitPolicyReconciler) gatewayWASMPlugin(ctx context.Context, gw *g
 }
 
 // returns nil when there is no rate limit policy to apply
-func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context, gw *gatewayapiv1alpha2.Gateway, rlpRefs []client.ObjectKey) (*rlptools.WASMPlugin, error) {
+func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context,
+	gw rlptools.GatewayWrapper, rlpRefs []client.ObjectKey) (*rlptools.WASMPlugin, error) {
 	logger, _ := logr.FromContext(ctx)
-	gwKey := client.ObjectKeyFromObject(gw)
-	// Load all relevant rate limit policies
+
 	routeRLPList := make([]*apimv1alpha1.RateLimitPolicy, 0)
-	gwRLPList := make([]*apimv1alpha1.RateLimitPolicy, 0)
+	var gwRLP *apimv1alpha1.RateLimitPolicy
 	for _, rlpKey := range rlpRefs {
 		rlp := &apimv1alpha1.RateLimitPolicy{}
 		err := r.Client().Get(ctx, rlpKey, rlp)
-		logger.V(1).Info("gatewayWASMPlugin", "get rlp", rlpKey, "err", err)
+		logger.V(1).Info("wasmPluginConfig", "get rlp", rlpKey, "err", err)
 		if err != nil {
 			return nil, err
 		}
@@ -133,20 +137,27 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context, gw *ga
 		if rlp.IsForHTTPRoute() {
 			routeRLPList = append(routeRLPList, rlp)
 		} else if rlp.IsForGateway() {
-			gwRLPList = append(gwRLPList, rlp)
+			if gwRLP == nil {
+				gwRLP = rlp
+			} else {
+				return nil, fmt.Errorf("wasmPluginConfig: multiple gateway RLP found and only one expected. rlp keys: %v", rlpRefs)
+			}
 		}
-	}
-
-	if len(routeRLPList) < 1 {
-		// not
-		return nil, nil
 	}
 
 	gatewayActions := rlptools.GatewayActionsByDomain{}
 
-	// iterate over HTTPRoute RLP's.
-	// Gateway level RLP's alone do not make sense.
-	// The request would be rejected by the router with 404
+	if gwRLP != nil {
+		if len(gw.Hostnames()) == 0 {
+			// wildcard domain
+			gatewayActions["*"] = append(gatewayActions["*"], rlptools.GatewayActionsFromRateLimitPolicy(gwRLP)...)
+		} else {
+			for _, gwHostname := range gw.Hostnames() {
+				gatewayActions[gwHostname] = append(gatewayActions[gwHostname], rlptools.GatewayActionsFromRateLimitPolicy(gwRLP)...)
+			}
+		}
+	}
+
 	for _, httpRouteRLP := range routeRLPList {
 		httpRoute, err := r.fetchHTTPRoute(ctx, httpRouteRLP)
 		if err != nil {
@@ -154,7 +165,7 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context, gw *ga
 		}
 
 		// gateways limits merged with the route level limits
-		mergedGatewayActions := mergeGatewayActions(httpRouteRLP, gwRLPList)
+		mergedGatewayActions := mergeGatewayActions(httpRouteRLP, gwRLP)
 		// routeLimits referenced by multiple hostnames
 		for _, hostname := range httpRoute.Spec.Hostnames {
 			gatewayActions[string(hostname)] = append(gatewayActions[string(hostname)], mergedGatewayActions...)
@@ -170,7 +181,7 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context, gw *ga
 	for domain, gatewayActionList := range gatewayActions {
 		rateLimitPolicy := rlptools.RateLimitPolicy{
 			Name:            domain,
-			RateLimitDomain: common.MarshallNamespace(gwKey, domain),
+			RateLimitDomain: common.MarshallNamespace(gw.Key(), domain),
 			UpstreamCluster: common.KuadrantRateLimitClusterName,
 			Hostnames:       []string{domain},
 			GatewayActions:  gatewayActionList,
@@ -182,20 +193,13 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context, gw *ga
 }
 
 // merge operations currently implemented with list append operation
-func mergeGatewayActions(routeRLP *apimv1alpha1.RateLimitPolicy, gwRLPs []*apimv1alpha1.RateLimitPolicy) []rlptools.GatewayAction {
-	gatewayActions := make([]rlptools.GatewayAction, 0)
+func mergeGatewayActions(routeRLP *apimv1alpha1.RateLimitPolicy, gwRLP *apimv1alpha1.RateLimitPolicy) []rlptools.GatewayAction {
+	gatewayActions := rlptools.GatewayActionsFromRateLimitPolicy(routeRLP)
 
-	// add route level gateway actions
-	for idx := range routeRLP.Spec.RateLimits {
-		gatewayActions = append(gatewayActions, rlptools.GatewayActionFromRateLimit(&routeRLP.Spec.RateLimits[idx]))
+	if gwRLP == nil {
+		return gatewayActions
 	}
 
-	// add gateway level limits
-	for _, gwRLP := range gwRLPs {
-		for idx := range gwRLP.Spec.RateLimits {
-			gatewayActions = append(gatewayActions, rlptools.GatewayActionFromRateLimit(&gwRLP.Spec.RateLimits[idx]))
-		}
-	}
-
-	return gatewayActions
+	// add gateway level actions
+	return append(gatewayActions, rlptools.GatewayActionsFromRateLimitPolicy(gwRLP)...)
 }

--- a/pkg/rlptools/gateway_utils.go
+++ b/pkg/rlptools/gateway_utils.go
@@ -197,3 +197,19 @@ func (g GatewayWrapper) DeleteRLP(rlpKey client.ObjectKey) bool {
 
 	return false
 }
+
+// Hostnames builds a list of hostnames from the listeners.
+func (g GatewayWrapper) Hostnames() []string {
+	hostnames := make([]string, 0)
+	if g.Gateway == nil {
+		return hostnames
+	}
+
+	for idx := range g.Spec.Listeners {
+		if g.Spec.Listeners[idx].Hostname != nil {
+			hostnames = append(hostnames, string(*g.Spec.Listeners[idx].Hostname))
+		}
+	}
+
+	return hostnames
+}

--- a/pkg/rlptools/limit_index.go
+++ b/pkg/rlptools/limit_index.go
@@ -205,6 +205,32 @@ func (l *LimitIndex) Equals(other *LimitIndex) bool {
 	return true
 }
 
+// NewLimitadorIndex builds index to manage limits indexed by domain indexed by gateways
+// yaml representation would be:
+//
+//	 ---
+//	 gateway_key1:
+//	   domain_1:
+//		 - maxValue: X
+//		   seconds: Y
+//		   conditions: [ ... ]
+//		   variables: [ ... ]
+//	   domain_2:
+//		 - maxValue: X
+//		   seconds: Y
+//		   conditions: [ ... ]
+//		   variables: [ ... ]
+//	 gateway_key2:
+//	   domain_1:
+//		 - maxValue: X
+//		   seconds: Y
+//		   conditions: [ ... ]
+//		   variables: [ ... ]
+//	   domain_2:
+//		 - maxValue: X
+//		   seconds: Y
+//		   conditions: [ ... ]
+//		   variables: [ ... ]
 func NewLimitadorIndex(limitador *limitadorv1alpha1.Limitador, logger logr.Logger) *LimitIndex {
 	limitIdx := &LimitIndex{
 		logger:        logger,

--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -25,15 +25,21 @@ type GatewayAction struct {
 	Rules []apimv1alpha1.Rule `json:"rules,omitempty"`
 }
 
-func GatewayActionFromRateLimit(rateLimit *apimv1alpha1.RateLimit) GatewayAction {
-	if rateLimit == nil {
-		return GatewayAction{}
+// GatewayActionsFromRateLimitPolicy return flatten list from GatewayAction from the RLP
+func GatewayActionsFromRateLimitPolicy(rlp *apimv1alpha1.RateLimitPolicy) []GatewayAction {
+	flattenActions := make([]GatewayAction, 0)
+	if rlp == nil {
+		return flattenActions
 	}
 
-	return GatewayAction{
-		Configurations: rateLimit.Configurations,
-		Rules:          rateLimit.Rules,
+	for idx := range rlp.Spec.RateLimits {
+		flattenActions = append(flattenActions, GatewayAction{
+			Configurations: rlp.Spec.RateLimits[idx].Configurations,
+			Rules:          rlp.Spec.RateLimits[idx].Rules,
+		})
 	}
+
+	return flattenActions
 }
 
 type RateLimitPolicy struct {


### PR DESCRIPTION
### what

Fix #197 

### how

Before merging route and gateway level limits/{gateway actions}, add gateway level limits/{gateway actions} for the hostnames defined in the gateway (falling back to global wildcard `*` if not defined)

### verification steps

Deploy the kuadrant controller

```
make local-setup
```
* deploy toystore service
```
kubectl apply -f examples/toystore/toystore.yaml
```
Create `toystore` HTTPRoute to configure routing to the toystore service

```yaml
kubectl apply -f - <<EOF
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: toystore
  labels:
    app: toystore
spec:
  parentRefs:
    - name: istio-ingressgateway
      namespace: istio-system
  hostnames: ["*.toystore.com"]
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/toy"
          method: GET
        - path:
            type: PathPrefix
            value: "/free"
          method: GET
        - path:
            type: Exact
            value: "/admin/toy"
          method: POST
      backendRefs:
        - name: toystore
          port: 80
EOF
```

![](https://i.imgur.com/rdN8lo3.png)

Check `toystore` HTTPRoute works and it is not rate limited.

`GET /toy`: no rate limiting
```
while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/toy | egrep --color "\b(429)\b|$"; sleep 1; done
```

`POST /admin/toy`: no rate limiting
```
while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" -X POST http://localhost:9080/admin/toy | egrep --color "\b(429)\b|$"; sleep 1; done
```

Adding gateway level RLP

| Policy | Rate Limits |
| ------------- | -----: |
| `POST /*` | **2** reqs / **10** secs (0.2 rps) |**

```yaml
kubectl apply -f - <<EOF
---
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: istio-gw
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  rateLimits:
    - rules:
      - methods: ["POST"]
      configurations:
        - actions:
            - generic_key:
                descriptor_key: expensive_op
                descriptor_value: "1"
      limits:
        - conditions: ["expensive_op == '1'"]
          maxValue: 2
          seconds: 10
          variables: []
EOF
```

![](https://i.imgur.com/ZspaKZB.png)

Validating the gateway level rate limit policy:

`GET /toy` : no rate limiting 
```
while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/toy | egrep --color "\b(429)\b|$"; sleep 1; done
```

`POST /admin/toy`:  expected to be rate limited @ **2** reqs / **10** secs (0.2 rps)
```
while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" -X POST http://localhost:9080/admin/toy | egrep --color "\b(429)\b|$"; sleep 1; done
```