### PR TITLE
default rules from httproute on RateLimitPolicy rules

### DIFF
--- a/pkg/rlptools/gateway_utils.go
+++ b/pkg/rlptools/gateway_utils.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
 	"github.com/kuadrant/kuadrant-controller/pkg/common"
 )
 
@@ -212,4 +213,98 @@ func (g GatewayWrapper) Hostnames() []string {
 	}
 
 	return hostnames
+}
+
+func RouteHostnames(route *gatewayapiv1alpha2.HTTPRoute) []string {
+	if route == nil {
+		return nil
+	}
+
+	if len(route.Spec.Hostnames) == 0 {
+		return []string{"*"}
+	}
+
+	hosts := make([]string, 0, len(route.Spec.Hostnames))
+
+	for _, hostname := range route.Spec.Hostnames {
+		hosts = append(hosts, string(hostname))
+	}
+
+	return hosts
+}
+
+// RulesFromHTTPRoute computes a list of rules from the HTTPRoute object
+func RulesFromHTTPRoute(route *gatewayapiv1alpha2.HTTPRoute) []apimv1alpha1.Rule {
+	if route == nil {
+		return nil
+	}
+
+	var rules []apimv1alpha1.Rule
+
+	for routeRuleIdx := range route.Spec.Rules {
+		for matchIdx := range route.Spec.Rules[routeRuleIdx].Matches {
+			match := &route.Spec.Rules[routeRuleIdx].Matches[matchIdx]
+
+			rule := apimv1alpha1.Rule{
+				Hosts: RouteHostnames(route),
+			}
+
+			rule.Methods = RouteHTTPMethodToRuleMethod(match.Method)
+			rule.Paths = routePathMatchToRulePath(match.Path)
+
+			if len(rule.Methods) != 0 || len(rule.Paths) != 0 {
+				// Only append rule when there are methods or path rules
+				// a valid rule must include HTTPRoute hostnames as well
+				rule.Hosts = RouteHostnames(route)
+				rules = append(rules, rule)
+			}
+		}
+	}
+
+	// If no rules compiled from the route, at least one rule for the hosts
+	if len(rules) == 0 {
+		rules = []apimv1alpha1.Rule{{Hosts: RouteHostnames(route)}}
+	}
+
+	return rules
+}
+
+// routePathMatchToRulePath converts HTTPRoute pathmatch rule to kuadrant's rule path
+func routePathMatchToRulePath(pathMatch *gatewayapiv1alpha2.HTTPPathMatch) []string {
+	if pathMatch == nil {
+		return nil
+	}
+
+	// Only support for Exact and Prefix match
+	if pathMatch.Type != nil && *pathMatch.Type != gatewayapiv1alpha2.PathMatchPathPrefix &&
+		*pathMatch.Type != gatewayapiv1alpha2.PathMatchExact {
+		return nil
+	}
+
+	suffix := ""
+	if pathMatch.Type == nil {
+		// defaults to path prefix match type
+		suffix = "*"
+	}
+	if *pathMatch.Type == gatewayapiv1alpha2.PathMatchPathPrefix {
+		suffix = "*"
+	}
+	if *pathMatch.Type == gatewayapiv1alpha2.PathMatchExact {
+		suffix = ""
+	}
+
+	val := "/"
+	if pathMatch.Value != nil {
+		val = *pathMatch.Value
+	}
+
+	return []string{val + suffix}
+}
+
+func RouteHTTPMethodToRuleMethod(httpMethod *gatewayapiv1alpha2.HTTPMethod) []string {
+	if httpMethod == nil {
+		return nil
+	}
+
+	return []string{string(*httpMethod)}
 }

--- a/pkg/rlptools/gateway_utils.go
+++ b/pkg/rlptools/gateway_utils.go
@@ -281,16 +281,11 @@ func routePathMatchToRulePath(pathMatch *gatewayapiv1alpha2.HTTPPathMatch) []str
 		return nil
 	}
 
+	// Exact path match
 	suffix := ""
-	if pathMatch.Type == nil {
+	if pathMatch.Type == nil || *pathMatch.Type == gatewayapiv1alpha2.PathMatchPathPrefix {
 		// defaults to path prefix match type
 		suffix = "*"
-	}
-	if *pathMatch.Type == gatewayapiv1alpha2.PathMatchPathPrefix {
-		suffix = "*"
-	}
-	if *pathMatch.Type == gatewayapiv1alpha2.PathMatchExact {
-		suffix = ""
 	}
 
 	val := "/"

--- a/pkg/rlptools/gateway_utils_test.go
+++ b/pkg/rlptools/gateway_utils_test.go
@@ -56,6 +56,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 		getMethod                                          = "GET"
 		catsPath                                           = "/cats"
 		dogsPath                                           = "/dogs"
+		rabbitsPath                                        = "/rabbits"
 		getHTTPMethod        gatewayapiv1alpha2.HTTPMethod = "GET"
 		postHTTPMethod       gatewayapiv1alpha2.HTTPMethod = "POST"
 		pathPrefix                                         = gatewayapiv1alpha2.PathMatchPathPrefix
@@ -67,6 +68,9 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 		dogsExactPatchMatch = gatewayapiv1alpha2.HTTPPathMatch{
 			Type:  &pathExact,
 			Value: &dogsPath,
+		}
+		rabbitsPrefixPatchMatch = gatewayapiv1alpha2.HTTPPathMatch{
+			Value: &rabbitsPath,
 		}
 	)
 
@@ -138,6 +142,26 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 			[]apimv1alpha1.Rule{{
 				Hosts: []string{"*"},
 				Paths: []string{"/cats*"},
+			}},
+		},
+		{
+			"with path and default path match type",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Rules: []gatewayapiv1alpha2.HTTPRouteRule{
+						{
+							Matches: []gatewayapiv1alpha2.HTTPRouteMatch{
+								{
+									Path: &rabbitsPrefixPatchMatch,
+								},
+							},
+						},
+					},
+				},
+			},
+			[]apimv1alpha1.Rule{{
+				Hosts: []string{"*"},
+				Paths: []string{"/rabbits*"},
 			}},
 		},
 		{

--- a/pkg/rlptools/gateway_utils_test.go
+++ b/pkg/rlptools/gateway_utils_test.go
@@ -1,0 +1,209 @@
+package rlptools
+
+import (
+	"reflect"
+	"testing"
+
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
+)
+
+func TestRouteHostnames(t *testing.T) {
+	testCases := []struct {
+		name     string
+		route    *gatewayapiv1alpha2.HTTPRoute
+		expected []string
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		},
+		{
+			"nil hostname",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Hostnames: nil,
+				},
+			},
+			[]string{"*"},
+		},
+		{
+			"basic",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com", "example.net", "test.example.net"},
+				},
+			},
+			[]string{"*.com", "example.net", "test.example.net"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			res := RouteHostnames(tc.route)
+			if !reflect.DeepEqual(res, tc.expected) {
+				subT.Errorf("result (%v) does not match expected (%v)", res, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRulesFromHTTPRoute(t *testing.T) {
+	var (
+		getMethod                                          = "GET"
+		catsPath                                           = "/cats"
+		dogsPath                                           = "/dogs"
+		getHTTPMethod        gatewayapiv1alpha2.HTTPMethod = "GET"
+		postHTTPMethod       gatewayapiv1alpha2.HTTPMethod = "POST"
+		pathPrefix                                         = gatewayapiv1alpha2.PathMatchPathPrefix
+		pathExact                                          = gatewayapiv1alpha2.PathMatchExact
+		catsPrefixPatchMatch                               = gatewayapiv1alpha2.HTTPPathMatch{
+			Type:  &pathPrefix,
+			Value: &catsPath,
+		}
+		dogsExactPatchMatch = gatewayapiv1alpha2.HTTPPathMatch{
+			Type:  &pathExact,
+			Value: &dogsPath,
+		}
+	)
+
+	testCases := []struct {
+		name     string
+		route    *gatewayapiv1alpha2.HTTPRoute
+		expected []apimv1alpha1.Rule
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		},
+		{
+			"nil rules",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Rules:     nil,
+					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
+				},
+			},
+			[]apimv1alpha1.Rule{{Hosts: []string{"*.com"}}},
+		},
+		{
+			"empty rules",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Rules:     make([]gatewayapiv1alpha2.HTTPRouteRule, 0),
+					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
+				},
+			},
+			[]apimv1alpha1.Rule{{Hosts: []string{"*.com"}}},
+		},
+		{
+			"with method",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Rules: []gatewayapiv1alpha2.HTTPRouteRule{
+						{
+							Matches: []gatewayapiv1alpha2.HTTPRouteMatch{
+								{
+									Method: &getHTTPMethod,
+								},
+							},
+						},
+					},
+				},
+			},
+			[]apimv1alpha1.Rule{{
+				Hosts:   []string{"*"},
+				Methods: []string{getMethod},
+			}},
+		},
+		{
+			"with path",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Rules: []gatewayapiv1alpha2.HTTPRouteRule{
+						{
+							Matches: []gatewayapiv1alpha2.HTTPRouteMatch{
+								{
+									Path: &catsPrefixPatchMatch,
+								},
+							},
+						},
+					},
+				},
+			},
+			[]apimv1alpha1.Rule{{
+				Hosts: []string{"*"},
+				Paths: []string{"/cats*"},
+			}},
+		},
+		{
+			"no paths or methods",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Rules: []gatewayapiv1alpha2.HTTPRouteRule{
+						{
+							Matches: []gatewayapiv1alpha2.HTTPRouteMatch{
+								{
+									Headers: []gatewayapiv1alpha2.HTTPHeaderMatch{
+										{
+											Name:  "someheader",
+											Value: "somevalue",
+										},
+									},
+								},
+							},
+						},
+					},
+					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
+				},
+			},
+			[]apimv1alpha1.Rule{{Hosts: []string{"*.com"}}},
+		},
+		{
+			"basic",
+			&gatewayapiv1alpha2.HTTPRoute{
+				Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
+					Rules: []gatewayapiv1alpha2.HTTPRouteRule{
+						{
+							// GET /cats*
+							// POST /dogs
+							Matches: []gatewayapiv1alpha2.HTTPRouteMatch{
+								{
+									Path:   &catsPrefixPatchMatch,
+									Method: &getHTTPMethod,
+								},
+								{
+									Path:   &dogsExactPatchMatch,
+									Method: &postHTTPMethod,
+								},
+							},
+						},
+					},
+				},
+			},
+			[]apimv1alpha1.Rule{
+				{
+					Hosts:   []string{"*.com"},
+					Methods: []string{"GET"},
+					Paths:   []string{"/cats*"},
+				}, {
+					Hosts:   []string{"*.com"},
+					Methods: []string{"POST"},
+					Paths:   []string{"/dogs"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			res := RulesFromHTTPRoute(tc.route)
+			if !reflect.DeepEqual(res, tc.expected) {
+				subT.Errorf("result (%+v) does not match expected (%+v)", res, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/rlptools/gateway_utils_test.go
+++ b/pkg/rlptools/gateway_utils_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package rlptools
 
 import (


### PR DESCRIPTION
### what

When the rules are empty (`null` or `empty list`), take the default values from the target resource (HTTPRoute). This implementation goes to the RateLimitPolicy

Partially implements https://github.com/Kuadrant/kuadrant-controller/issues/190

### Verification steps

Run dev env

```
make local-setup
```

Create HTTPRoute

```yaml
kubectl apply -f - <<EOF
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: toystore
  labels:
    app: toystore
spec:
  parentRefs:
    - name: istio-ingressgateway
      namespace: istio-system
  hostnames: ["*.toystore.com"]
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/toy"
          method: GET
        - path:
            type: Exact
            value: "/car"
          method: POST
      backendRefs:
        - name: toystore
          port: 80
EOF
```

Create RateLimitPolicy, with two configurations, one including some rules, another with empty rules

```yaml
kubectl apply -f - <<EOF
---
apiVersion: apim.kuadrant.io/v1alpha1
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rateLimits:
    - rules:
        - hosts: ["rate-limited.toystore.com"]
      configurations:
        - actions:
            - generic_key:
                descriptor_key: "limited"
                descriptor_value: "1"
      limits:
        - conditions:
            - "limited == 1"
          maxValue: 5
          seconds: 10
          variables: []
    - configurations:
        - actions:
            - generic_key:
                descriptor_key: "limited2"
                descriptor_value: "2"
      limits:
        - conditions:
            - "limited2 == 1"
          maxValue: 2
          seconds: 10
          variables: []
EOF
```
Check the wasm plugin object to see the default rules read from the network resource. One of the rule list is copied directly from the policy, the other is generated from the network resource matching rules.

```yaml
k get wasmplugin kuadrant-istio-ingressgateway -n istio-system -o yaml | yq_pretty 
apiVersion: extensions.istio.io/v1alpha1
kind: WasmPlugin
metadata:
  creationTimestamp: "2022-09-12T12:07:41Z"
  generation: 1
  name: kuadrant-istio-ingressgateway
  namespace: istio-system
  resourceVersion: "2416"
  uid: cca72a57-29e2-4464-861a-a0136ea879f2
spec:
  phase: STATS
  pluginConfig:
    failure_mode_deny: true
    rate_limit_policies:
      - gateway_actions:
          - configurations:
              - actions:
                  - generic_key:
                      descriptor_key: limited
                      descriptor_value: "1"
            rules:
              - hosts:
                  - rate-limited.toystore.com
          - configurations:
              - actions:
                  - generic_key:
                      descriptor_key: limited2
                      descriptor_value: "2"
            rules:
              - hosts:
                  - '*.toystore.com'
                methods:
                  - GET
                paths:
                  - /toy*
              - hosts:
                  - '*.toystore.com'
                methods:
                  - POST
                paths:
                  - /car
        hostnames:
          - '*.toystore.com'
        name: '*.toystore.com'
        rate_limit_domain: istio-system/istio-ingressgateway#*.toystore.com
        upstream_cluster: kuadrant-rate-limiting-service
  selector:
    matchLabels:
      istio: ingressgateway
  url: oci://quay.io/kuadrant/wasm-shim:latest
```
