### PR TITLE
bump golangci linting tool to 1.49

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 $(GOLANGCI-LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_PATH)/bin v1.46.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_PATH)/bin v1.49.0
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI-LINT) ## Download golangci-lint locally if necessary.

--- a/controllers/apim/helper_test.go
+++ b/controllers/apim/helper_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -19,7 +19,7 @@ import (
 
 func ApplyResources(fileName string, k8sClient client.Client, ns string) error {
 	logf.Log.Info("ApplyResources", "Resource file", fileName)
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ func ApplyResources(fileName string, k8sClient client.Client, ns string) error {
 
 	// the maximum size used to buffer a doc 5M
 	buf := make([]byte, 5*1024*1024)
-	docDecoder := yaml.NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader(data)))
+	docDecoder := yaml.NewDocumentDecoder(io.NopCloser(bytes.NewReader(data)))
 
 	for {
 		n, err := docDecoder.Read(buf)


### PR DESCRIPTION
### what 

Bump linting tool version to 1.49 (supports go 1.19)

Fix lint issues