### PR TITLE
Refactor: dry enhancements

### DIFF
--- a/apis/apim/v1alpha1/ratelimitpolicy_types.go
+++ b/apis/apim/v1alpha1/ratelimitpolicy_types.go
@@ -254,22 +254,6 @@ func (r *RateLimitPolicy) Validate() error {
 	return nil
 }
 
-func (r *RateLimitPolicy) IsForHTTPRoute() bool {
-	if err := r.Validate(); err != nil {
-		return false
-	}
-
-	return r.Spec.TargetRef.Kind == gatewayapiv1alpha2.Kind("HTTPRoute")
-}
-
-func (r *RateLimitPolicy) IsForGateway() bool {
-	if err := r.Validate(); err != nil {
-		return false
-	}
-
-	return r.Spec.TargetRef.Kind == gatewayapiv1alpha2.Kind("Gateway")
-}
-
 func (r *RateLimitPolicy) TargetKey() client.ObjectKey {
 	tmpNS := r.Namespace
 	if r.Spec.TargetRef.Namespace != nil {

--- a/controllers/apim/authpolicy_controller.go
+++ b/controllers/apim/authpolicy_controller.go
@@ -224,7 +224,7 @@ func (r *AuthPolicyReconciler) reconcileAuthRules(ctx context.Context, ap *apimv
 	}
 
 	targetObjectKind := "Gateway"
-	if common.IsHTTPRoute(ap.Spec.TargetRef) {
+	if common.IsTargetRefHTTPRoute(ap.Spec.TargetRef) {
 		targetObjectKind = "HTTPRoute"
 	}
 
@@ -300,7 +300,7 @@ func (r *AuthPolicyReconciler) removeIstioAuthPolicy(ctx context.Context, ap *ap
 	}
 
 	targetObjectKind := "Gateway"
-	if common.IsHTTPRoute(ap.Spec.TargetRef) {
+	if common.IsTargetRefHTTPRoute(ap.Spec.TargetRef) {
 		targetObjectKind = "HTTPRoute"
 	}
 

--- a/controllers/apim/authpolicy_controller.go
+++ b/controllers/apim/authpolicy_controller.go
@@ -11,7 +11,6 @@ import (
 	secv1beta1resources "istio.io/client-go/pkg/apis/security/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -22,13 +21,11 @@ import (
 	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
 	"github.com/kuadrant/kuadrant-controller/pkg/common"
 	"github.com/kuadrant/kuadrant-controller/pkg/reconcilers"
-	"github.com/kuadrant/kuadrant-controller/pkg/rlptools"
 )
 
 // AuthPolicyReconciler reconciles a AuthPolicy object
 type AuthPolicyReconciler struct {
-	*reconcilers.BaseReconciler
-	Scheme *runtime.Scheme
+	reconcilers.TargetRefReconciler
 }
 
 const authPolicyFinalizer = "authpolicy.kuadrant.io/finalizer"
@@ -66,6 +63,11 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 		if err := r.removeAuthSchemes(ctx, &ap); err != nil {
 			return ctrl.Result{}, err
 		}
+
+		if err := r.deleteNetworkResourceBackReference(ctx, &ap); err != nil {
+			return ctrl.Result{}, err
+		}
+
 		controllerutil.RemoveFinalizer(&ap, authPolicyFinalizer)
 		if err := r.UpdateResource(ctx, &ap); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
@@ -136,27 +138,9 @@ func (r *AuthPolicyReconciler) reconcileSpec(ctx context.Context, ap *apimv1alph
 }
 
 func (r *AuthPolicyReconciler) enforceHierarchicalConstraints(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
-	targetObj, err := r.fetchTargetObject(ctx, ap)
+	targetHostnames, err := r.TargetHostnames(ctx, ap.Spec.TargetRef, ap.Namespace)
 	if err != nil {
 		return err
-	}
-
-	netResourceHosts := make([]string, 0)
-	switch netResource := targetObj.(type) {
-	case *gatewayapiv1alpha2.HTTPRoute:
-		for _, hostname := range netResource.Spec.Hostnames {
-			netResourceHosts = append(netResourceHosts, string(hostname))
-		}
-	case *gatewayapiv1alpha2.Gateway:
-		for idx := range netResource.Spec.Listeners {
-			if netResource.Spec.Listeners[idx].Hostname != nil {
-				netResourceHosts = append(netResourceHosts, string(*netResource.Spec.Listeners[idx].Hostname))
-			}
-		}
-	}
-
-	if len(netResourceHosts) == 0 {
-		netResourceHosts = append(netResourceHosts, string("*"))
 	}
 
 	ruleHosts := make([]string, 0)
@@ -164,11 +148,11 @@ func (r *AuthPolicyReconciler) enforceHierarchicalConstraints(ctx context.Contex
 		ruleHosts = append(ruleHosts, rule.Hosts...)
 	}
 
-	if valid, invalidHost := common.ValidSubdomains(netResourceHosts, ruleHosts); !valid {
+	if valid, invalidHost := common.ValidSubdomains(targetHostnames, ruleHosts); !valid {
 		return fmt.Errorf("rule host (%s) does not follow any hierarchical constraints", invalidHost)
 	}
 
-	if valid, invalidHost := common.ValidSubdomains(netResourceHosts, ap.Spec.AuthScheme.Hosts); !valid {
+	if valid, invalidHost := common.ValidSubdomains(targetHostnames, ap.Spec.AuthScheme.Hosts); !valid {
 		return fmt.Errorf("host defined in authscheme (%s) does not follow any hierarchical constraints", invalidHost)
 	}
 
@@ -199,18 +183,6 @@ func (r *AuthPolicyReconciler) reconcileAuthSchemes(ctx context.Context, ap *api
 func (r *AuthPolicyReconciler) reconcileAuthRules(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
 	logger, _ := logr.FromContext(ctx)
 
-	targetObj, err := r.fetchTargetObject(ctx, ap)
-	targetObjectKind := string(ap.Spec.TargetRef.Kind)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("referenced %s not found", targetObjectKind)
-			return nil
-		}
-		return err
-	}
-
-	gwKeys := TargetedGatewayKeys(targetObj)
-
 	toRules := []*secv1beta1types.Rule_To{}
 	for _, rule := range ap.Spec.AuthRules {
 		toRules = append(toRules, &secv1beta1types.Rule_To{
@@ -223,27 +195,43 @@ func (r *AuthPolicyReconciler) reconcileAuthRules(ctx context.Context, ap *apimv
 	}
 
 	if len(toRules) == 0 {
+		targetObj, err := r.FetchValidTargetRef(ctx, ap.Spec.TargetRef, ap.Namespace)
+		if err != nil {
+			return err
+		}
 		switch route := targetObj.(type) {
 		case *gatewayapiv1alpha2.HTTPRoute:
 			// rules not set and targeting a HTTPRoute
 			// Compile rules from the route
-			rules := rlptools.RulesFromHTTPRoute(route)
-			for idx := range rules {
+			httpRouterules := common.RulesFromHTTPRoute(route)
+			for idx := range httpRouterules {
+				var tmp []string
 				toRules = append(toRules, &secv1beta1types.Rule_To{
 					Operation: &secv1beta1types.Operation{
-						Hosts:   rules[idx].Hosts,
-						Methods: rules[idx].Methods,
-						Paths:   rules[idx].Paths,
+						// copy slice
+						Hosts:   append(tmp, httpRouterules[idx].Hosts...),
+						Methods: append(tmp, httpRouterules[idx].Methods...),
+						Paths:   append(tmp, httpRouterules[idx].Paths...),
 					},
 				})
 			}
 		}
 	}
 
+	gwKeys, err := r.TargetedGatewayKeys(ctx, ap.Spec.TargetRef, ap.Namespace)
+	if err != nil {
+		return nil
+	}
+
+	targetObjectKind := "Gateway"
+	if common.IsHTTPRoute(ap.Spec.TargetRef) {
+		targetObjectKind = "HTTPRoute"
+	}
+
 	for _, gwKey := range gwKeys {
 		authPolicy := secv1beta1resources.AuthorizationPolicy{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getAuthPolicyName(gwKey.Name, targetObj.GetName(), targetObjectKind),
+				Name:      getAuthPolicyName(gwKey.Name, string(ap.Spec.TargetRef.Name), targetObjectKind),
 				Namespace: gwKey.Namespace,
 			},
 			Spec: secv1beta1types.AuthorizationPolicy{
@@ -275,38 +263,8 @@ func (r *AuthPolicyReconciler) reconcileAuthRules(ctx context.Context, ap *apimv
 }
 
 func (r *AuthPolicyReconciler) reconcileNetworkResourceBackReference(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
-	logger, _ := logr.FromContext(ctx)
-	targetObj, err := r.fetchTargetObject(ctx, ap)
-	if err != nil {
-		// The object should also exist
-		return err
-	}
-
-	targetObjKind := targetObj.GetObjectKind().GroupVersionKind().Kind
-
-	// Reconcile the back reference:
-	targetObjAnnotations := targetObj.GetAnnotations()
-	if targetObjAnnotations == nil {
-		targetObjAnnotations = map[string]string{}
-	}
-
-	apKey := client.ObjectKeyFromObject(ap)
-	val, present := targetObjAnnotations[common.AuthPolicyBackRefAnnotation]
-	if present {
-		if val != apKey.String() {
-			return fmt.Errorf("the target %s {%s} is already referenced by authpolicy %s", targetObjKind, client.ObjectKeyFromObject(targetObj).String(), apKey.String())
-		}
-	} else {
-		targetObjAnnotations[common.AuthPolicyBackRefAnnotation] = apKey.String()
-		targetObj.SetAnnotations(targetObjAnnotations)
-		err := r.UpdateResource(ctx, targetObj)
-		logger.V(1).Info(fmt.Sprintf("reconcileNetworkResourceBackReference: update %s", targetObjKind), targetObjKind, client.ObjectKeyFromObject(targetObj).String(), "err", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return r.ReconcileTargetBackReference(ctx, client.ObjectKeyFromObject(ap), ap.Spec.TargetRef,
+		ap.Namespace, common.AuthPolicyBackRefAnnotation)
 }
 
 func (r *AuthPolicyReconciler) removeAuthSchemes(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
@@ -336,22 +294,20 @@ func (r *AuthPolicyReconciler) removeIstioAuthPolicy(ctx context.Context, ap *ap
 	logger, _ := logr.FromContext(ctx)
 	logger.Info("Removing Istio's AuthorizationPolicy")
 
-	targetObj, err := r.fetchTargetObject(ctx, ap)
-	targetObjectKind := string(ap.Spec.TargetRef.Kind)
+	gwKeys, err := r.TargetedGatewayKeys(ctx, ap.Spec.TargetRef, ap.Namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("referenced kind not found", "kind", targetObjectKind)
-			return nil
-		}
-		return err
+		return nil
 	}
 
-	gwKeys := TargetedGatewayKeys(targetObj)
+	targetObjectKind := "Gateway"
+	if common.IsHTTPRoute(ap.Spec.TargetRef) {
+		targetObjectKind = "HTTPRoute"
+	}
 
 	for _, gwKey := range gwKeys {
 		istioAuthPolicy := &secv1beta1resources.AuthorizationPolicy{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getAuthPolicyName(gwKey.Name, targetObj.GetName(), targetObjectKind),
+				Name:      getAuthPolicyName(gwKey.Name, string(ap.Spec.TargetRef.Name), targetObjectKind),
 				Namespace: gwKey.Namespace,
 			},
 		}
@@ -366,31 +322,9 @@ func (r *AuthPolicyReconciler) removeIstioAuthPolicy(ctx context.Context, ap *ap
 	return nil
 }
 
-// fetchHTTPRoute fetches the HTTPRoute described in targetRef *within* AuthPolicy's namespace.
-func (r *AuthPolicyReconciler) fetchTargetObject(ctx context.Context, ap *apimv1alpha1.AuthPolicy) (client.Object, error) {
-	logger, _ := logr.FromContext(ctx)
-	key := client.ObjectKey{
-		Name:      string(ap.Spec.TargetRef.Name),
-		Namespace: ap.Namespace,
-	}
-
-	var targetObject client.Object
-	if ap.Spec.TargetRef.Kind == "HTTPRoute" {
-		targetObject = &gatewayapiv1alpha2.HTTPRoute{}
-	} else {
-		targetObject = &gatewayapiv1alpha2.Gateway{}
-	}
-	err := r.Client().Get(ctx, key, targetObject)
-	logger.V(1).Info("fetchTargetObject", string(ap.Spec.TargetRef.Kind), key, "err", err)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := TargetableObject(targetObject); err != nil {
-		return nil, err
-	}
-
-	return targetObject, nil
+func (r *AuthPolicyReconciler) deleteNetworkResourceBackReference(ctx context.Context, ap *apimv1alpha1.AuthPolicy) error {
+	return r.DeleteTargetBackReference(ctx, client.ObjectKeyFromObject(ap), ap.Spec.TargetRef,
+		ap.Namespace, common.AuthPolicyBackRefAnnotation)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/apim/gateway_rlp_eventmapper.go
+++ b/controllers/apim/gateway_rlp_eventmapper.go
@@ -11,6 +11,7 @@ import (
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
+	"github.com/kuadrant/kuadrant-controller/pkg/common"
 	"github.com/kuadrant/kuadrant-controller/pkg/rlptools"
 )
 
@@ -29,7 +30,7 @@ func (h *GatewayRateLimitPolicyEventMapper) MapRouteRateLimitPolicy(obj client.O
 	}
 
 	// filter out all RLP not targeting a gateway
-	if !rlp.IsForGateway() {
+	if !common.IsTargetRefGateway(rlp.Spec.TargetRef) {
 		return []reconcile.Request{}
 	}
 

--- a/controllers/apim/ratelimitpolicy_limits.go
+++ b/controllers/apim/ratelimitpolicy_limits.go
@@ -116,9 +116,9 @@ func (r *RateLimitPolicyReconciler) gatewayLimits(ctx context.Context,
 			return nil, err
 		}
 
-		if common.IsHTTPRoute(rlp.Spec.TargetRef) {
+		if common.IsTargetRefHTTPRoute(rlp.Spec.TargetRef) {
 			routeRLPList = append(routeRLPList, rlp)
-		} else if common.IsGateway(rlp.Spec.TargetRef) {
+		} else if common.IsTargetRefGateway(rlp.Spec.TargetRef) {
 			if gwRLP == nil {
 				gwRLP = rlp
 			} else {

--- a/controllers/apim/ratelimitpolicy_limits.go
+++ b/controllers/apim/ratelimitpolicy_limits.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
+	"github.com/kuadrant/kuadrant-controller/pkg/common"
 	"github.com/kuadrant/kuadrant-controller/pkg/rlptools"
 )
 
@@ -115,9 +116,9 @@ func (r *RateLimitPolicyReconciler) gatewayLimits(ctx context.Context,
 			return nil, err
 		}
 
-		if rlp.IsForHTTPRoute() {
+		if common.IsHTTPRoute(rlp.Spec.TargetRef) {
 			routeRLPList = append(routeRLPList, rlp)
-		} else if rlp.IsForGateway() {
+		} else if common.IsGateway(rlp.Spec.TargetRef) {
 			if gwRLP == nil {
 				gwRLP = rlp
 			} else {
@@ -140,7 +141,7 @@ func (r *RateLimitPolicyReconciler) gatewayLimits(ctx context.Context,
 	}
 
 	for _, httpRouteRLP := range routeRLPList {
-		httpRoute, err := r.fetchHTTPRoute(ctx, httpRouteRLP)
+		httpRoute, err := r.FetchValidHTTPRoute(ctx, httpRouteRLP.TargetKey())
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/apim/ratelimitpolicy_status.go
+++ b/controllers/apim/ratelimitpolicy_status.go
@@ -68,7 +68,7 @@ func (r *RateLimitPolicyReconciler) calculateStatus(ctx context.Context, rlp *ap
 	}
 
 	// Only makes sense for rlp's targeting a route
-	if rlp.IsForHTTPRoute() {
+	if common.IsTargetRefHTTPRoute(rlp.Spec.TargetRef) {
 		gwRateLimits, err := r.gatewaysRateLimits(ctx, rlp)
 		if err != nil {
 			return nil, err
@@ -104,7 +104,7 @@ func (r *RateLimitPolicyReconciler) availableCondition(specErr error) *metav1.Co
 // gateways where this rate limit policy adds configuration
 func (r *RateLimitPolicyReconciler) gatewaysRateLimits(ctx context.Context, rlp *apimv1alpha1.RateLimitPolicy) ([]apimv1alpha1.GatewayRateLimits, error) {
 	logger, _ := logr.FromContext(ctx)
-	gwKeys, err := r.rlpGatewayKeys(ctx, rlp)
+	gwKeys, err := r.TargetedGatewayKeys(ctx, rlp.Spec.TargetRef, rlp.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			gwKeys = make([]client.ObjectKey, 0)

--- a/controllers/apim/ratelimitpolicy_wasm_plugins.go
+++ b/controllers/apim/ratelimitpolicy_wasm_plugins.go
@@ -135,9 +135,9 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context,
 			return nil, err
 		}
 
-		if rlp.IsForHTTPRoute() {
+		if common.IsHTTPRoute(rlp.Spec.TargetRef) {
 			routeRLPList = append(routeRLPList, rlp)
-		} else if rlp.IsForGateway() {
+		} else if common.IsGateway(rlp.Spec.TargetRef) {
 			if gwRLP == nil {
 				gwRLP = rlp
 			} else {
@@ -160,7 +160,7 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context,
 	}
 
 	for _, httpRouteRLP := range routeRLPList {
-		httpRoute, err := r.fetchHTTPRoute(ctx, httpRouteRLP)
+		httpRoute, err := r.FetchValidHTTPRoute(ctx, httpRouteRLP.TargetKey())
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/apim/ratelimitpolicy_wasm_plugins.go
+++ b/controllers/apim/ratelimitpolicy_wasm_plugins.go
@@ -135,9 +135,9 @@ func (r *RateLimitPolicyReconciler) wasmPluginConfig(ctx context.Context,
 			return nil, err
 		}
 
-		if common.IsHTTPRoute(rlp.Spec.TargetRef) {
+		if common.IsTargetRefHTTPRoute(rlp.Spec.TargetRef) {
 			routeRLPList = append(routeRLPList, rlp)
-		} else if common.IsGateway(rlp.Spec.TargetRef) {
+		} else if common.IsTargetRefGateway(rlp.Spec.TargetRef) {
 			if gwRLP == nil {
 				gwRLP = rlp
 			} else {

--- a/controllers/apim/suite_test.go
+++ b/controllers/apim/suite_test.go
@@ -98,8 +98,9 @@ var _ = BeforeSuite(func() {
 	)
 
 	err = (&AuthPolicyReconciler{
-		BaseReconciler: authPolicyBaseReconciler,
-		Scheme:         mgr.GetScheme(),
+		TargetRefReconciler: reconcilers.TargetRefReconciler{
+			BaseReconciler: authPolicyBaseReconciler,
+		},
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -121,8 +121,9 @@ func main() {
 	)
 
 	if err = (&apimcontrollers.RateLimitPolicyReconciler{
-		BaseReconciler: rateLimitPolicyBaseReconciler,
-		Scheme:         mgr.GetScheme(),
+		TargetRefReconciler: reconcilers.TargetRefReconciler{
+			BaseReconciler: rateLimitPolicyBaseReconciler,
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RateLimitPolicy")
 		os.Exit(1)
@@ -135,8 +136,9 @@ func main() {
 	)
 
 	if err = (&apimcontrollers.AuthPolicyReconciler{
-		BaseReconciler: authPolicyBaseReconciler,
-		Scheme:         mgr.GetScheme(),
+		TargetRefReconciler: reconcilers.TargetRefReconciler{
+			BaseReconciler: authPolicyBaseReconciler,
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AuthPolicy")
 		os.Exit(1)

--- a/pkg/common/gatewayapi_utils.go
+++ b/pkg/common/gatewayapi_utils.go
@@ -1,0 +1,108 @@
+package common
+
+import (
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type HTTPRouteRule struct {
+	Paths   []string
+	Methods []string
+	Hosts   []string
+}
+
+func IsHTTPRoute(targetRef gatewayapiv1alpha2.PolicyTargetReference) bool {
+	return targetRef.Kind == gatewayapiv1alpha2.Kind("HTTPRoute")
+}
+
+func IsGateway(targetRef gatewayapiv1alpha2.PolicyTargetReference) bool {
+	return targetRef.Kind == gatewayapiv1alpha2.Kind("Gateway")
+}
+
+func RouteHTTPMethodToRuleMethod(httpMethod *gatewayapiv1alpha2.HTTPMethod) []string {
+	if httpMethod == nil {
+		return nil
+	}
+
+	return []string{string(*httpMethod)}
+}
+
+func RouteHostnames(route *gatewayapiv1alpha2.HTTPRoute) []string {
+	if route == nil {
+		return nil
+	}
+
+	if len(route.Spec.Hostnames) == 0 {
+		return []string{"*"}
+	}
+
+	hosts := make([]string, 0, len(route.Spec.Hostnames))
+
+	for _, hostname := range route.Spec.Hostnames {
+		hosts = append(hosts, string(hostname))
+	}
+
+	return hosts
+}
+
+// RulesFromHTTPRoute computes a list of rules from the HTTPRoute object
+func RulesFromHTTPRoute(route *gatewayapiv1alpha2.HTTPRoute) []HTTPRouteRule {
+	if route == nil {
+		return nil
+	}
+
+	var rules []HTTPRouteRule
+
+	for routeRuleIdx := range route.Spec.Rules {
+		for matchIdx := range route.Spec.Rules[routeRuleIdx].Matches {
+			match := &route.Spec.Rules[routeRuleIdx].Matches[matchIdx]
+
+			rule := HTTPRouteRule{
+				Hosts: RouteHostnames(route),
+			}
+
+			rule.Methods = RouteHTTPMethodToRuleMethod(match.Method)
+			rule.Paths = routePathMatchToRulePath(match.Path)
+
+			if len(rule.Methods) != 0 || len(rule.Paths) != 0 {
+				// Only append rule when there are methods or path rules
+				// a valid rule must include HTTPRoute hostnames as well
+				rule.Hosts = RouteHostnames(route)
+				rules = append(rules, rule)
+			}
+		}
+	}
+
+	// If no rules compiled from the route, at least one rule for the hosts
+	if len(rules) == 0 {
+		rules = []HTTPRouteRule{{Hosts: RouteHostnames(route)}}
+	}
+
+	return rules
+}
+
+// routePathMatchToRulePath converts HTTPRoute pathmatch rule to kuadrant's rule path
+func routePathMatchToRulePath(pathMatch *gatewayapiv1alpha2.HTTPPathMatch) []string {
+	if pathMatch == nil {
+		return nil
+	}
+
+	// Only support for Exact and Prefix match
+	if pathMatch.Type != nil && *pathMatch.Type != gatewayapiv1alpha2.PathMatchPathPrefix &&
+		*pathMatch.Type != gatewayapiv1alpha2.PathMatchExact {
+		return nil
+	}
+
+	// Exact path match
+	suffix := ""
+	if pathMatch.Type == nil || *pathMatch.Type == gatewayapiv1alpha2.PathMatchPathPrefix {
+		// defaults to path prefix match type
+		suffix = "*"
+	}
+
+	val := "/"
+	if pathMatch.Value != nil {
+		val = *pathMatch.Value
+	}
+
+	return []string{val + suffix}
+}

--- a/pkg/common/gatewayapi_utils.go
+++ b/pkg/common/gatewayapi_utils.go
@@ -10,11 +10,11 @@ type HTTPRouteRule struct {
 	Hosts   []string
 }
 
-func IsHTTPRoute(targetRef gatewayapiv1alpha2.PolicyTargetReference) bool {
+func IsTargetRefHTTPRoute(targetRef gatewayapiv1alpha2.PolicyTargetReference) bool {
 	return targetRef.Kind == gatewayapiv1alpha2.Kind("HTTPRoute")
 }
 
-func IsGateway(targetRef gatewayapiv1alpha2.PolicyTargetReference) bool {
+func IsTargetRefGateway(targetRef gatewayapiv1alpha2.PolicyTargetReference) bool {
 	return targetRef.Kind == gatewayapiv1alpha2.Kind("Gateway")
 }
 

--- a/pkg/common/gatewayapi_utils_test.go
+++ b/pkg/common/gatewayapi_utils_test.go
@@ -1,14 +1,12 @@
 //go:build unit
 
-package rlptools
+package common
 
 import (
 	"reflect"
 	"testing"
 
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-
-	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
 )
 
 func TestRouteHostnames(t *testing.T) {
@@ -77,7 +75,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 	testCases := []struct {
 		name     string
 		route    *gatewayapiv1alpha2.HTTPRoute
-		expected []apimv1alpha1.Rule
+		expected []HTTPRouteRule
 	}{
 		{
 			"nil",
@@ -92,7 +90,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
 				},
 			},
-			[]apimv1alpha1.Rule{{Hosts: []string{"*.com"}}},
+			[]HTTPRouteRule{{Hosts: []string{"*.com"}}},
 		},
 		{
 			"empty rules",
@@ -102,7 +100,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
 				},
 			},
-			[]apimv1alpha1.Rule{{Hosts: []string{"*.com"}}},
+			[]HTTPRouteRule{{Hosts: []string{"*.com"}}},
 		},
 		{
 			"with method",
@@ -119,7 +117,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			[]apimv1alpha1.Rule{{
+			[]HTTPRouteRule{{
 				Hosts:   []string{"*"},
 				Methods: []string{getMethod},
 			}},
@@ -139,7 +137,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			[]apimv1alpha1.Rule{{
+			[]HTTPRouteRule{{
 				Hosts: []string{"*"},
 				Paths: []string{"/cats*"},
 			}},
@@ -159,7 +157,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			[]apimv1alpha1.Rule{{
+			[]HTTPRouteRule{{
 				Hosts: []string{"*"},
 				Paths: []string{"/rabbits*"},
 			}},
@@ -185,7 +183,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					Hostnames: []gatewayapiv1alpha2.Hostname{"*.com"},
 				},
 			},
-			[]apimv1alpha1.Rule{{Hosts: []string{"*.com"}}},
+			[]HTTPRouteRule{{Hosts: []string{"*.com"}}},
 		},
 		{
 			"basic",
@@ -210,7 +208,7 @@ func TestRulesFromHTTPRoute(t *testing.T) {
 					},
 				},
 			},
-			[]apimv1alpha1.Rule{
+			[]HTTPRouteRule{
 				{
 					Hosts:   []string{"*.com"},
 					Methods: []string{"GET"},

--- a/pkg/reconcilers/targetref_reconciler.go
+++ b/pkg/reconcilers/targetref_reconciler.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-controller/pkg/common"
+)
+
+type TargetRefReconciler struct {
+	*BaseReconciler
+}
+
+// blank assignment to verify that BaseReconciler implements reconcile.Reconciler
+var _ reconcile.Reconciler = &TargetRefReconciler{}
+
+func (r *TargetRefReconciler) Reconcile(context.Context, ctrl.Request) (ctrl.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func (r *TargetRefReconciler) FetchValidGateway(ctx context.Context, key client.ObjectKey) (*gatewayapiv1alpha2.Gateway, error) {
+	logger, _ := logr.FromContext(ctx)
+
+	gw := &gatewayapiv1alpha2.Gateway{}
+	err := r.Client().Get(ctx, key, gw)
+	logger.V(1).Info("FetchValidGateway", "gateway", key, "err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	if meta.IsStatusConditionFalse(gw.Status.Conditions, "Ready") {
+		return nil, fmt.Errorf("FetchValidGateway: gateway (%v) not ready", key)
+	}
+
+	return gw, nil
+}
+
+func (r *TargetRefReconciler) FetchValidHTTPRoute(ctx context.Context, key client.ObjectKey) (*gatewayapiv1alpha2.HTTPRoute, error) {
+	logger, _ := logr.FromContext(ctx)
+
+	httpRoute := &gatewayapiv1alpha2.HTTPRoute{}
+	err := r.Client().Get(ctx, key, httpRoute)
+	logger.V(1).Info("FetchValidHTTPRoute", "httpRoute", key, "err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check HTTProute parents (gateways) in the status object
+	// if any of the current parent gateways reports not "Admitted", return error
+	for _, parentRef := range httpRoute.Spec.CommonRouteSpec.ParentRefs {
+		routeParentStatus := func(pRef gatewayapiv1alpha2.ParentRef) *gatewayapiv1alpha2.RouteParentStatus {
+			for idx := range httpRoute.Status.RouteStatus.Parents {
+				if reflect.DeepEqual(pRef, httpRoute.Status.RouteStatus.Parents[idx].ParentRef) {
+					return &httpRoute.Status.RouteStatus.Parents[idx]
+				}
+			}
+
+			return nil
+		}(parentRef)
+
+		if routeParentStatus == nil {
+			continue
+		}
+
+		if meta.IsStatusConditionFalse(routeParentStatus.Conditions, "Accepted") {
+			return nil, fmt.Errorf("FetchValidHTTPRoute: httproute (%v) not accepted", key)
+		}
+	}
+
+	return httpRoute, nil
+}
+
+// FetchValidTargetRef fetches the target reference object and checks the status is valid
+func (r *TargetRefReconciler) FetchValidTargetRef(ctx context.Context, targetRef gatewayapiv1alpha2.PolicyTargetReference, defaultNs string) (client.Object, error) {
+	tmpNS := defaultNs
+	if targetRef.Namespace != nil {
+		tmpNS = string(*targetRef.Namespace)
+	}
+
+	objKey := client.ObjectKey{Name: string(targetRef.Name), Namespace: tmpNS}
+
+	if common.IsHTTPRoute(targetRef) {
+		return r.FetchValidHTTPRoute(ctx, objKey)
+	} else if common.IsGateway(targetRef) {
+		return r.FetchValidGateway(ctx, objKey)
+	}
+
+	return nil, fmt.Errorf("FetchValidTargetRef: targetRef (%v) to unknown network resource", targetRef)
+}
+
+// TargetedGatewayKeys returns the list of gateways that are being referenced from the target.
+func (r *TargetRefReconciler) TargetedGatewayKeys(ctx context.Context, targetRef gatewayapiv1alpha2.PolicyTargetReference, defaultNs string) ([]client.ObjectKey, error) {
+	gwKeys := make([]client.ObjectKey, 0)
+
+	if common.IsHTTPRoute(targetRef) {
+		tmpNS := defaultNs
+		if targetRef.Namespace != nil {
+			tmpNS = string(*targetRef.Namespace)
+		}
+		objKey := client.ObjectKey{Name: string(targetRef.Name), Namespace: tmpNS}
+		httpRoute, err := r.FetchValidHTTPRoute(ctx, objKey)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, parentRef := range httpRoute.Spec.CommonRouteSpec.ParentRefs {
+			gwKey := client.ObjectKey{Name: string(parentRef.Name), Namespace: httpRoute.Namespace}
+			if parentRef.Namespace != nil {
+				gwKey.Namespace = string(*parentRef.Namespace)
+			}
+			gwKeys = append(gwKeys, gwKey)
+		}
+	} else if common.IsGateway(targetRef) {
+		gwKey := client.ObjectKey{Name: string(targetRef.Name), Namespace: defaultNs}
+		if targetRef.Namespace != nil {
+			gwKey.Namespace = string(*targetRef.Namespace)
+		}
+		gwKeys = []client.ObjectKey{gwKey}
+	}
+
+	return gwKeys, nil
+}
+
+func (r *TargetRefReconciler) TargetHostnames(ctx context.Context, targetRef gatewayapiv1alpha2.PolicyTargetReference, defaultNs string) ([]string, error) {
+	targetObj, err := r.FetchValidTargetRef(ctx, targetRef, defaultNs)
+	if err != nil {
+		return nil, err
+	}
+
+	netResourceHosts := make([]string, 0)
+	switch netResource := targetObj.(type) {
+	case *gatewayapiv1alpha2.HTTPRoute:
+		for _, hostname := range netResource.Spec.Hostnames {
+			netResourceHosts = append(netResourceHosts, string(hostname))
+		}
+	case *gatewayapiv1alpha2.Gateway:
+		for idx := range netResource.Spec.Listeners {
+			if netResource.Spec.Listeners[idx].Hostname != nil {
+				netResourceHosts = append(netResourceHosts, string(*netResource.Spec.Listeners[idx].Hostname))
+			}
+		}
+	}
+
+	if len(netResourceHosts) == 0 {
+		netResourceHosts = append(netResourceHosts, string("*"))
+	}
+
+	return netResourceHosts, nil
+}
+
+// ReconcileTargetBackReference adds policy key in annotations of the target object
+func (r *TargetRefReconciler) ReconcileTargetBackReference(ctx context.Context,
+	policyKey client.ObjectKey, targetRef gatewayapiv1alpha2.PolicyTargetReference,
+	defaultNs string, annotationName string) error {
+	logger, _ := logr.FromContext(ctx)
+	targetObj, err := r.FetchValidTargetRef(ctx, targetRef, defaultNs)
+	if err != nil {
+		// The object should also exist
+		return err
+	}
+
+	targetObjKey := client.ObjectKeyFromObject(targetObj)
+	targetObjType := targetObj.GetObjectKind().GroupVersionKind()
+
+	// Reconcile the back reference:
+	objAnnotations := targetObj.GetAnnotations()
+	if objAnnotations == nil {
+		objAnnotations = map[string]string{}
+	}
+
+	val, ok := objAnnotations[annotationName]
+	if ok {
+		if val != policyKey.String() {
+			return fmt.Errorf("the %s target %s is already referenced by policy %s",
+				targetObjType, targetObjKey, policyKey.String())
+		}
+	} else {
+		objAnnotations[annotationName] = policyKey.String()
+		targetObj.SetAnnotations(objAnnotations)
+		err := r.UpdateResource(ctx, targetObj)
+		logger.V(1).Info("ReconcileTargetBackReference: update target object",
+			"type", targetObjType, "name", targetObjKey, "err", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *TargetRefReconciler) DeleteTargetBackReference(ctx context.Context,
+	policyKey client.ObjectKey, targetRef gatewayapiv1alpha2.PolicyTargetReference,
+	defaultNs string, annotationName string) error {
+	logger, _ := logr.FromContext(ctx)
+
+	targetObj, err := r.FetchValidTargetRef(ctx, targetRef, defaultNs)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	targetObjKey := client.ObjectKeyFromObject(targetObj)
+	targetObjType := targetObj.GetObjectKind().GroupVersionKind()
+
+	// Reconcile the back reference:
+	objAnnotations := targetObj.GetAnnotations()
+	if objAnnotations == nil {
+		objAnnotations = map[string]string{}
+	}
+
+	if _, ok := objAnnotations[annotationName]; ok {
+		delete(objAnnotations, annotationName)
+		targetObj.SetAnnotations(objAnnotations)
+		err := r.UpdateResource(ctx, targetObj)
+		logger.V(1).Info("DeleteTargetBackReference: update network resource",
+			"type", targetObjType, "name", targetObjKey, "err", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/reconcilers/targetref_reconciler.go
+++ b/pkg/reconcilers/targetref_reconciler.go
@@ -104,9 +104,9 @@ func (r *TargetRefReconciler) FetchValidTargetRef(ctx context.Context, targetRef
 
 	objKey := client.ObjectKey{Name: string(targetRef.Name), Namespace: tmpNS}
 
-	if common.IsHTTPRoute(targetRef) {
+	if common.IsTargetRefHTTPRoute(targetRef) {
 		return r.FetchValidHTTPRoute(ctx, objKey)
-	} else if common.IsGateway(targetRef) {
+	} else if common.IsTargetRefGateway(targetRef) {
 		return r.FetchValidGateway(ctx, objKey)
 	}
 
@@ -117,7 +117,7 @@ func (r *TargetRefReconciler) FetchValidTargetRef(ctx context.Context, targetRef
 func (r *TargetRefReconciler) TargetedGatewayKeys(ctx context.Context, targetRef gatewayapiv1alpha2.PolicyTargetReference, defaultNs string) ([]client.ObjectKey, error) {
 	gwKeys := make([]client.ObjectKey, 0)
 
-	if common.IsHTTPRoute(targetRef) {
+	if common.IsTargetRefHTTPRoute(targetRef) {
 		tmpNS := defaultNs
 		if targetRef.Namespace != nil {
 			tmpNS = string(*targetRef.Namespace)
@@ -135,7 +135,7 @@ func (r *TargetRefReconciler) TargetedGatewayKeys(ctx context.Context, targetRef
 			}
 			gwKeys = append(gwKeys, gwKey)
 		}
-	} else if common.IsGateway(targetRef) {
+	} else if common.IsTargetRefGateway(targetRef) {
 		gwKey := client.ObjectKey{Name: string(targetRef.Name), Namespace: defaultNs}
 		if targetRef.Namespace != nil {
 			gwKey.Namespace = string(*targetRef.Namespace)

--- a/pkg/reconcilers/targetref_reconciler_test.go
+++ b/pkg/reconcilers/targetref_reconciler_test.go
@@ -1,0 +1,190 @@
+//go:build unit
+
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-controller/pkg/log"
+)
+
+func TestFetchValidGateway(t *testing.T) {
+	var (
+		namespace = "operator-unittest"
+		gwName    = "my-gateway"
+	)
+	baseCtx := context.Background()
+	ctx := logr.NewContext(baseCtx, log.Log)
+
+	s := scheme.Scheme
+	err := appsv1.AddToScheme(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = gatewayapiv1alpha2.AddToScheme(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	existingGateway := &gatewayapiv1alpha2.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "gateway.networking.k8s.io/v1alpha2",
+			Kind:       "Gateway",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gwName,
+			Namespace: namespace,
+		},
+		Spec: gatewayapiv1alpha2.GatewaySpec{
+			GatewayClassName: "istio",
+		},
+		Status: gatewayapiv1alpha2.GatewayStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{existingGateway}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	recorder := record.NewFakeRecorder(1000)
+
+	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader, log.Log, recorder)
+	targetRefReconciler := TargetRefReconciler{
+		BaseReconciler: baseReconciler,
+	}
+
+	key := client.ObjectKey{Name: gwName, Namespace: namespace}
+
+	res, err := targetRefReconciler.FetchValidGateway(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res == nil {
+		t.Fatal("res is nil")
+	}
+
+	if !reflect.DeepEqual(res.Spec, existingGateway.Spec) {
+		t.Fatal("res spec not as expected")
+	}
+}
+
+func TestFetchValidHTTPRoute(t *testing.T) {
+	var (
+		namespace = "operator-unittest"
+		routeName = "my-route"
+	)
+	baseCtx := context.Background()
+	ctx := logr.NewContext(baseCtx, log.Log)
+
+	s := scheme.Scheme
+	err := appsv1.AddToScheme(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = gatewayapiv1alpha2.AddToScheme(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	existingRoute := &gatewayapiv1alpha2.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "gateway.networking.k8s.io/v1alpha2",
+			Kind:       "HTTPRoute",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+		},
+		Spec: gatewayapiv1alpha2.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1alpha2.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1alpha2.ParentRef{
+					{
+						Name: "gwName",
+					},
+				},
+			},
+		},
+		Status: gatewayapiv1alpha2.HTTPRouteStatus{
+			RouteStatus: gatewayapiv1alpha2.RouteStatus{
+				Parents: []gatewayapiv1alpha2.RouteParentStatus{
+					{
+						ParentRef: gatewayapiv1alpha2.ParentRef{
+							Name: "gwName",
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Accepted",
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{existingRoute}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+	clientAPIReader := fake.NewFakeClient(objs...)
+	recorder := record.NewFakeRecorder(1000)
+
+	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader, log.Log, recorder)
+	targetRefReconciler := TargetRefReconciler{
+		BaseReconciler: baseReconciler,
+	}
+
+	key := client.ObjectKey{Name: routeName, Namespace: namespace}
+
+	res, err := targetRefReconciler.FetchValidHTTPRoute(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res == nil {
+		t.Fatal("res is nil")
+	}
+
+	if !reflect.DeepEqual(res.Spec, existingRoute.Spec) {
+		t.Fatal("res spec not as expected")
+	}
+}

--- a/pkg/rlptools/gateway_utils.go
+++ b/pkg/rlptools/gateway_utils.go
@@ -6,7 +6,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	apimv1alpha1 "github.com/kuadrant/kuadrant-controller/apis/apim/v1alpha1"
 	"github.com/kuadrant/kuadrant-controller/pkg/common"
 )
 
@@ -213,93 +212,4 @@ func (g GatewayWrapper) Hostnames() []string {
 	}
 
 	return hostnames
-}
-
-func RouteHostnames(route *gatewayapiv1alpha2.HTTPRoute) []string {
-	if route == nil {
-		return nil
-	}
-
-	if len(route.Spec.Hostnames) == 0 {
-		return []string{"*"}
-	}
-
-	hosts := make([]string, 0, len(route.Spec.Hostnames))
-
-	for _, hostname := range route.Spec.Hostnames {
-		hosts = append(hosts, string(hostname))
-	}
-
-	return hosts
-}
-
-// RulesFromHTTPRoute computes a list of rules from the HTTPRoute object
-func RulesFromHTTPRoute(route *gatewayapiv1alpha2.HTTPRoute) []apimv1alpha1.Rule {
-	if route == nil {
-		return nil
-	}
-
-	var rules []apimv1alpha1.Rule
-
-	for routeRuleIdx := range route.Spec.Rules {
-		for matchIdx := range route.Spec.Rules[routeRuleIdx].Matches {
-			match := &route.Spec.Rules[routeRuleIdx].Matches[matchIdx]
-
-			rule := apimv1alpha1.Rule{
-				Hosts: RouteHostnames(route),
-			}
-
-			rule.Methods = RouteHTTPMethodToRuleMethod(match.Method)
-			rule.Paths = routePathMatchToRulePath(match.Path)
-
-			if len(rule.Methods) != 0 || len(rule.Paths) != 0 {
-				// Only append rule when there are methods or path rules
-				// a valid rule must include HTTPRoute hostnames as well
-				rule.Hosts = RouteHostnames(route)
-				rules = append(rules, rule)
-			}
-		}
-	}
-
-	// If no rules compiled from the route, at least one rule for the hosts
-	if len(rules) == 0 {
-		rules = []apimv1alpha1.Rule{{Hosts: RouteHostnames(route)}}
-	}
-
-	return rules
-}
-
-// routePathMatchToRulePath converts HTTPRoute pathmatch rule to kuadrant's rule path
-func routePathMatchToRulePath(pathMatch *gatewayapiv1alpha2.HTTPPathMatch) []string {
-	if pathMatch == nil {
-		return nil
-	}
-
-	// Only support for Exact and Prefix match
-	if pathMatch.Type != nil && *pathMatch.Type != gatewayapiv1alpha2.PathMatchPathPrefix &&
-		*pathMatch.Type != gatewayapiv1alpha2.PathMatchExact {
-		return nil
-	}
-
-	// Exact path match
-	suffix := ""
-	if pathMatch.Type == nil || *pathMatch.Type == gatewayapiv1alpha2.PathMatchPathPrefix {
-		// defaults to path prefix match type
-		suffix = "*"
-	}
-
-	val := "/"
-	if pathMatch.Value != nil {
-		val = *pathMatch.Value
-	}
-
-	return []string{val + suffix}
-}
-
-func RouteHTTPMethodToRuleMethod(httpMethod *gatewayapiv1alpha2.HTTPMethod) []string {
-	if httpMethod == nil {
-		return nil
-	}
-
-	return []string{string(*httpMethod)}
 }

--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -37,7 +37,7 @@ func GatewayActionsFromRateLimitPolicy(rlp *apimv1alpha1.RateLimitPolicy, route 
 		// if HTTPRoute is available, fill empty rules with defaults from the route
 		rules := rlp.Spec.RateLimits[idx].Rules
 		if route != nil && len(rules) == 0 {
-			rules = RulesFromHTTPRoute(route)
+			rules = HTTPRouteRulesToRLPRules(common.RulesFromHTTPRoute(route))
 		}
 
 		flattenActions = append(flattenActions, GatewayAction{
@@ -47,6 +47,20 @@ func GatewayActionsFromRateLimitPolicy(rlp *apimv1alpha1.RateLimitPolicy, route 
 	}
 
 	return flattenActions
+}
+
+func HTTPRouteRulesToRLPRules(httpRouteRules []common.HTTPRouteRule) []apimv1alpha1.Rule {
+	rlpRules := make([]apimv1alpha1.Rule, len(httpRouteRules))
+	for idx := range httpRouteRules {
+		var tmp []string
+		rlpRules = append(rlpRules, apimv1alpha1.Rule{
+			// copy slice
+			Paths:   append(tmp, httpRouteRules[idx].Paths...),
+			Methods: append(tmp, httpRouteRules[idx].Methods...),
+			Hosts:   append(tmp, httpRouteRules[idx].Hosts...),
+		})
+	}
+	return rlpRules
 }
 
 type RateLimitPolicy struct {


### PR DESCRIPTION
### what

This is a refactor of the ratelimitpolicy and authpolicy controller to use common code that was repeated.

For that, a new base reconciler is created called `TargetRefReconciler` which is meant for controllers reconciling CRD's having a [targetRef from the Gateway API policy attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#target-reference-api). Also, a new file in the package `commons` called `gatewayapi_utils.go` with common functionality regarding gateway API resources.

* Remove back reference of the authpolicy in the target object when the authpolicy is being deleted.
* Unittests of the common code