### PR TITLE
support for arm64 arch for istio-ingressgateway

### DIFF
--- a/config/dependencies/istio/operator.yaml
+++ b/config/dependencies/istio/operator.yaml
@@ -19,6 +19,47 @@ spec:
       - enabled: true
         name: istio-ingressgateway
         k8s:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - "amd64"
+                    - "arm64"
+                    - "ppc64le"
+                    - "s390x"
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 2
+                preference:
+                  matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - "amd64"
+              - weight: 2
+                preference:
+                  matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - "arm64"
+              - weight: 2
+                preference:
+                  matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - "ppc64le"
+              - weight: 2
+                preference:
+                  matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - "s390x"
           service:
             type: NodePort
             ports:


### PR DESCRIPTION
Sets node affinity to the Istio gateway deployment listing arm64 architecture amongst the required ones.
Otherwise, the 'istio-ingressgateway' pod won't start on clusters running on darwin/amr64 platform.

Closes #168.

----

### Verification steps

1. On macOS arm64, run:
  ```sh
  make local-setup
  ```
2. Verify the `istio-ingressgateway` pod starts