### PR TITLE
Informing the repo has been merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 🛑 This repository is DEPRECATED!
+This project has been merged into [Kuadrant Operator](https://github.com/Kuadrant/kuadrant-operator/)
+<hr/>
+
 # Kuadrant Controller
 
 [![Code Style](https://github.com/Kuadrant/kuadrant-controller/actions/workflows/code-style.yaml/badge.svg)](https://github.com/Kuadrant/kuadrant-controller/actions/workflows/code-style.yaml)


### PR DESCRIPTION
It will inform the deprecation in the readme file as it follows:

# 🛑 This repository is DEPRECATED!
This project has been merged into [Kuadrant Operator](https://github.com/Kuadrant/kuadrant-operator/)
<hr/>

# Kuadrant Controller

[![Code Style](https://github.com/Kuadrant/kuadrant-controller/actions/workflows/code-style.yaml/badge.svg)](https://github.com/Kuadrant/kuadrant-controller/actions/workflows/code-style.yaml)
[![Testing](https://github.com/Kuadrant/kuadrant-controller/actions/workflows/testing.yaml/badge.svg)](https://github.com/Kuadrant/kuadrant-controller/actions/workflows/testing.yaml)
[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
....